### PR TITLE
Decompile small main helpers

### DIFF
--- a/src/main/18B8.c
+++ b/src/main/18B8.c
@@ -978,7 +978,10 @@ void SetupGamepad(void) {
     D_80062FA0 = 0;
 }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/18B8", func_8001C484);
+void func_8001C484(s32 arg0) {
+    D_80062E9C = arg0;
+    D_80062E94 = 0x14;
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/18B8", func_8001C498);
 
@@ -1264,11 +1267,29 @@ void func_8001F6E4(s16 arg0, s16 arg1, s16 arg2) {
 
 INCLUDE_ASM("asm/us/main/nonmatchings/18B8", func_8001F710);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/18B8", func_8001FA28);
+void func_8001FA28(s32 arg0) {
+    arg0 &= 0xFFFF;
+    D_8009A000[0] = 0x30;
+    D_8009A004[0] = arg0;
+    D_8009A008[0] = arg0;
+    func_8002DA7C();
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/18B8", func_8001FA68);
+void func_8001FA68(s32 arg0) {
+    D_8009A000[0] = 0x28;
+    arg0 &= 0xFFFF;
+    D_8009A004[0] = 0x40;
+    D_8009A008[0] = arg0;
+    func_8002DA7C();
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/18B8", func_8001FAAC);
+void func_8001FAAC(s32 arg0) {
+    D_8009A000[0] = 0x29;
+    arg0 &= 0xFFFF;
+    D_8009A004[0] = 0x40;
+    D_8009A008[0] = arg0;
+    func_8002DA7C();
+}
 
 void func_8001FAF0(void) {}
 
@@ -1329,7 +1350,16 @@ void func_800211B8(s32 arg0) { D_80062DEC = arg0; }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/18B8", func_800211C4);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/18B8", func_8002120C);
+void func_8002120C(s32 arg0) {
+    s32 prev;
+
+    prev = D_80062DD4;
+    D_80062DD4 = arg0;
+    D_80062DD0 = prev;
+    if (arg0 != 0 && ((u32)(prev - 3) >= 2 || (u32)(arg0 - 3) >= 2)) {
+        func_800211C4(arg0);
+    }
+}
 
 void func_80021258(s32 arg0) { func_80015248(13, arg0, 8); }
 

--- a/src/main/18B8.c
+++ b/src/main/18B8.c
@@ -1267,25 +1267,22 @@ void func_8001F6E4(s16 arg0, s16 arg1, s16 arg2) {
 
 INCLUDE_ASM("asm/us/main/nonmatchings/18B8", func_8001F710);
 
-void func_8001FA28(s32 arg0) {
-    arg0 &= 0xFFFF;
+void func_8001FA28(u16 arg0) {
     D_8009A000[0] = 0x30;
     D_8009A004[0] = arg0;
     D_8009A008[0] = arg0;
     func_8002DA7C();
 }
 
-void func_8001FA68(s32 arg0) {
+void func_8001FA68(u16 arg0) {
     D_8009A000[0] = 0x28;
-    arg0 &= 0xFFFF;
     D_8009A004[0] = 0x40;
     D_8009A008[0] = arg0;
     func_8002DA7C();
 }
 
-void func_8001FAAC(s32 arg0) {
+void func_8001FAAC(u16 arg0) {
     D_8009A000[0] = 0x29;
-    arg0 &= 0xFFFF;
     D_8009A004[0] = 0x40;
     D_8009A008[0] = arg0;
     func_8002DA7C();
@@ -1356,7 +1353,7 @@ void func_8002120C(s32 arg0) {
     prev = D_80062DD4;
     D_80062DD4 = arg0;
     D_80062DD0 = prev;
-    if (arg0 != 0 && ((u32)(prev - 3) >= 2 || (u32)(arg0 - 3) >= 2)) {
+    if (arg0 != 0 && (prev < 3 || prev > 4 || arg0 < 3 || arg0 > 4)) {
         func_800211C4(arg0);
     }
 }


### PR DESCRIPTION
I am still getting my feet wet here, so I kept this intentionally small and focused.

This PR decompiles five small helper functions in `src/main/18B8.c`:

- `func_8001C484`
- `func_8001FA28`
- `func_8001FA68`
- `func_8001FAAC`
- `func_8002120C`

A couple of names seem likely from behavior, but I left them unnamed to avoid overreaching:

- `func_8001FA28`, `func_8001FA68`, and `func_8001FAAC` look like they enqueue simple commands through `D_8009A000` / `D_8009A004` / `D_8009A008`, then flush or submit through `func_8002DA7C`.
- `func_8002120C` looks like a state transition helper that stores the previous value in `D_80062DD0` and updates `D_80062DD4`, only calling `func_800211C4` for selected transitions.

Checked locally with Docker:

```
make format
ninja build/us/main.exe
sha1sum -c /tmp/main.sha1
```

`build/us/main.exe` matches SHA1: `a95e8b16b97071203b953bb81a33980509262f30`.
