### PR TITLE
field: decompile small opcode handlers and helper functions

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -339,7 +339,8 @@ typedef struct {
 } Unk80074EA4; // size:0x84
 
 typedef struct {
-    u8 unk0[0x28];
+    u8 unk0[0x26];
+    s16 movieState;
     u16 unk28; // number of models
     u16 unk2A; // pc model id
     u16 unk2C; // idle animation id
@@ -349,12 +350,12 @@ typedef struct {
     u8 unk33;  // suspend walk animation
     u8 unk34;  // menus disabled
     u8 unk35;
-    u8 unk36;  // map jump disabled
-    u8 unk37;  // SCRLO set
-    u8 unk38;  // MPDSP set
-    u8 unk39;  // movie cam disabled
-    u8 unk3A;  // background movie enabled
-    u8 unk3B;  // battles disabled
+    u8 unk36; // map jump disabled
+    u8 scrloSet;
+    u8 mpdspSet;
+    u8 movieCamDisabled;
+    u8 backgroundMovieEnabled;
+    u8 battlesDisabled;
     u8 unk3C;  // encounter table id
     u8 unk3D;  // battle mode related
     u16 unk3E; // battle mode related
@@ -440,6 +441,7 @@ extern u8 D_80083184[0x40];
 extern u16 D_800831FC[48]; // program counters for active entity scripts
 extern u8 D_8008326C;
 extern s32 D_80083274;
+extern s16 D_8008327E[];
 extern s16 D_800832A0;
 extern s32 D_80083338;
 extern s8 D_80095DCC;

--- a/src/field/field.c
+++ b/src/field/field.c
@@ -736,7 +736,6 @@ s32 func_800C50EC(void) {
         *(&D_8009C6DC[D_800831FC[D_800722C4]] + 1);
     entityId = D_800722C4;
     D_800831FC[entityId] = D_800831FC[entityId] + 2;
-    __asm__ volatile("");
     return 0;
 }
 
@@ -749,7 +748,6 @@ s32 func_800C5194(void) {
     D_8009C6E0->scrloSet = *(&D_8009C6DC[D_800831FC[D_800722C4]] + 1);
     entityId = D_800722C4;
     D_800831FC[entityId] = D_800831FC[entityId] + 2;
-    __asm__ volatile("");
     return 0;
 }
 
@@ -766,7 +764,6 @@ s32 func_800C5414(void) {
     D_8009C6E0->battlesDisabled = *(&D_8009C6DC[D_800831FC[D_800722C4]] + 1);
     entityId = D_800722C4;
     D_800831FC[entityId] = D_800831FC[entityId] + 2;
-    __asm__ volatile("");
     return 0;
 }
 
@@ -779,7 +776,6 @@ s32 func_800C54BC(void) {
     D_8009C6E0->mpdspSet = *(&D_8009C6DC[D_800831FC[D_800722C4]] + 1);
     entityId = D_800722C4;
     D_800831FC[entityId] = D_800831FC[entityId] + 2;
-    __asm__ volatile("");
     return 0;
 }
 
@@ -792,7 +788,6 @@ s32 func_800C5564(void) {
     D_8009C6E0->movieCamDisabled = *(&D_8009C6DC[D_800831FC[D_800722C4]] + 1);
     entityId = D_800722C4;
     D_800831FC[entityId] = D_800831FC[entityId] + 2;
-    __asm__ volatile("");
     return 0;
 }
 
@@ -802,7 +797,6 @@ s32 func_800C560C(void) {
     }
     D_8009C6E0->unk0[1] = 26;
     D_8009C6E0->movieState = 0;
-    __asm__ volatile("");
     return 1;
 }
 

--- a/src/field/field.c
+++ b/src/field/field.c
@@ -17,6 +17,8 @@ extern char D_800E0208[16]; // '0' to 'F' for hex digits
 extern char D_800A0270[4];
 extern s8 D_800E0628;
 extern s8 D_800E0630;
+extern u8 D_800E08C0[];
+extern s16 D_800DF120[][2];
 extern u16 D_800E1024;
 extern s16 D_800E41B8;
 extern s16 D_800E41C0;
@@ -115,9 +117,9 @@ INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800A82A0);
 
 INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800A8304);
 
-INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800A8600);
+s16 func_800A8600(u8 arg0) { return D_800DF120[arg0][0]; }
 
-INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800A8620);
+s16 func_800A8620(u8 arg0) { return D_800DF120[arg0][1]; }
 
 INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800A8640);
 
@@ -577,7 +579,16 @@ INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800C43C4);
 
 INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800C45AC);
 
-INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800C46A4);
+void func_800C46A4(void) {
+    s32 i;
+    s16* p;
+
+    D_8009A000[0] = 0;
+    for (i = 5, p = &D_8009A000[10]; i >= 0; i--) {
+        *(s32*)(p + 2) = 0;
+        p -= 2;
+    }
+}
 
 INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800C46D0);
 
@@ -715,21 +726,85 @@ s32 SetMusicLock(void) {
     return 0;
 }
 
-INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800C50EC);
+s32 func_800C50EC(void) {
+    s32 entityId;
 
-INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800C5194);
+    if (D_8009D820 & 3) {
+        func_800BEAD4("bgmovie", 1);
+    }
+    D_8009C6E0->backgroundMovieEnabled =
+        *(&D_8009C6DC[D_800831FC[D_800722C4]] + 1);
+    entityId = D_800722C4;
+    D_800831FC[entityId] = D_800831FC[entityId] + 2;
+    __asm__ volatile("");
+    return 0;
+}
+
+s32 func_800C5194(void) {
+    s32 entityId;
+
+    if (D_8009D820 & 3) {
+        func_800BEAD4("scrlo", 1);
+    }
+    D_8009C6E0->scrloSet = *(&D_8009C6DC[D_800831FC[D_800722C4]] + 1);
+    entityId = D_800722C4;
+    D_800831FC[entityId] = D_800831FC[entityId] + 2;
+    __asm__ volatile("");
+    return 0;
+}
 
 INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800C523C);
 
 INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800C532C);
 
-INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800C5414);
+s32 func_800C5414(void) {
+    s32 entityId;
 
-INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800C54BC);
+    if (D_8009D820 & 3) {
+        func_800BEAD4("btlon", 1);
+    }
+    D_8009C6E0->battlesDisabled = *(&D_8009C6DC[D_800831FC[D_800722C4]] + 1);
+    entityId = D_800722C4;
+    D_800831FC[entityId] = D_800831FC[entityId] + 2;
+    __asm__ volatile("");
+    return 0;
+}
 
-INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800C5564);
+s32 func_800C54BC(void) {
+    s32 entityId;
 
-INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800C560C);
+    if (D_8009D820 & 3) {
+        func_800BEAD4("mpdsp", 1);
+    }
+    D_8009C6E0->mpdspSet = *(&D_8009C6DC[D_800831FC[D_800722C4]] + 1);
+    entityId = D_800722C4;
+    D_800831FC[entityId] = D_800831FC[entityId] + 2;
+    __asm__ volatile("");
+    return 0;
+}
+
+s32 func_800C5564(void) {
+    s32 entityId;
+
+    if (D_8009D820 & 3) {
+        func_800BEAD4("mvcam", 1);
+    }
+    D_8009C6E0->movieCamDisabled = *(&D_8009C6DC[D_800831FC[D_800722C4]] + 1);
+    entityId = D_800722C4;
+    D_800831FC[entityId] = D_800831FC[entityId] + 2;
+    __asm__ volatile("");
+    return 0;
+}
+
+s32 func_800C560C(void) {
+    if (D_8009D820 & 3) {
+        func_800BEAD4("gmovr", 0);
+    }
+    D_8009C6E0->unk0[1] = 26;
+    D_8009C6E0->movieState = 0;
+    __asm__ volatile("");
+    return 1;
+}
 
 INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800C5668);
 
@@ -1172,7 +1247,7 @@ INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800D4C68);
 
 INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800D4E24);
 
-INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800D4E88);
+void func_800D4E88(s16 arg0, s16 arg1) { D_8008327E[arg0 * 24] = arg1; }
 
 INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800D4EB4);
 
@@ -1257,7 +1332,7 @@ INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800D83A8);
 
 INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800D8420);
 
-INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800D8498);
+s32 func_800D8498(s16 arg0) { return D_800E08C0[arg0 * 378] == 0; }
 
 INCLUDE_ASM("asm/us/field/nonmatchings/field", func_800D84CC);
 


### PR DESCRIPTION
Decompiles 11 small functions in the FIELD overlay:

- `func_800C50EC`, `func_800C5194`, `func_800C5414`, `func_800C54BC`, `func_800C5564` - script opcode handlers (bgmovie, scrlo, btlon, mpdsp, mvcam) that read a byte argument into game state flags
- `func_800C560C` - gmovr opcode handler
- `func_800A8600` / `func_800A8620` - getters for an s16 pair table at `D_800DF120`
- `func_800C46A4` - clears the command word at `D_8009A000` and its six parameter words
- `func_800D4E88` - writes an s16 into a 48-byte stride table at `D_8008327E`
- `func_800D8498` - checks whether a 378-byte stride record at `D_800E08C0` is empty

Also names the `Unk8009C6E0` fields used by the opcode handlers (`scrloSet`, `mpdspSet`, `movieCamDisabled`, `backgroundMovieEnabled`, `battlesDisabled`, `movieState`).

All overlays build with matching checksums.

Note: the opcode handlers end with `__asm__ volatile("")` to match. I couldn't find a plain C construct that reproduces the original codegen without it, suggestions welcome.