### PR TITLE
battle: decompile combatant-effect table handler func_800A8D18

### DIFF
--- a/src/battle/battle.c
+++ b/src/battle/battle.c
@@ -577,7 +577,13 @@ INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800A8CC8);
 
 void func_800A8D04(void) { D_80063014->unk48 = 2; }
 
-INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800A8D18);
+// seed this combatant's unk50 (a flag word later read by the damage formula
+// in func_800AD804 -- bit 0x80 there appears to exempt a hit from the
+// reduced per-target damage otherwise applied when an action strikes
+// multiple targets) with a per-slot default, but only if nothing has set
+// unk50 explicitly yet this turn (see func_800A8D60's sentinel check)
+void func_800A8D60(s32 arg0);
+void func_800A8D18(void) { func_800A8D60(D_800F5EFC[D_80063014->unk0 * 0x18]); }
 
 void func_800A8D60(s32 arg0) {
     if (D_80063014->unk50 == 0xFF) {

--- a/src/battle/battle_private.h
+++ b/src/battle/battle_private.h
@@ -430,6 +430,8 @@ extern u8 D_800F5630;
 extern u16 D_800F5634;
 extern u8 D_800F5638;
 extern u8 D_800F563C;
+extern u8 D_800F5EFC[]; // per-slot formation-setup config, 0x18 B stride; byte
+                        // 0 -> func_800A8D18
 extern BattleMenuWidget D_800F90C6[];
 extern u8 D_80151698;
 extern u8 D_80166F75;


### PR DESCRIPTION
Forwards a per-combatant lookup byte to func_800A8D60. Kept global: referenced from a function-pointer table, not called directly.