### PR TITLE
menu: decompile func_801D0BA0 (item-menu widget/state init)

### DIFF
--- a/src/main/ovl.c
+++ b/src/main/ovl.c
@@ -4,13 +4,14 @@ void func_8002368C();
 void func_801D0000();
 void func_801D069C();
 void func_801D05C0();
+void func_801D0BA0();
 void* D_800493A8[] = {
-    func_8002368C,     (void*)0x801D0BA0, (void*)0x801D0164, (void*)0x801D3CB0,
+    func_8002368C,     func_801D0BA0,     (void*)0x801D0164, (void*)0x801D3CB0,
     (void*)0x801D0574, (void*)0x801D0040, func_801D0000,     (void*)0x801D006C,
     func_801D069C,     (void*)0x801D0C1C, func_801D05C0,     (void*)0x801D0198,
-    func_801D0000,     (void*)0x801D006C, (void*)0x801D0BA0, (void*)0x801D0574,
-    (void*)0x801D0BA0, (void*)0x801D0BA0, (void*)0x801D0BA0, (void*)0x801D0BA0,
-    (void*)0x801D0BA0,
+    func_801D0000,     (void*)0x801D006C, func_801D0BA0,     (void*)0x801D0574,
+    func_801D0BA0,     func_801D0BA0,     func_801D0BA0,     func_801D0BA0,
+    func_801D0BA0,
 };
 
 void func_80023AD4();

--- a/src/menu/itemmenu.c
+++ b/src/menu/itemmenu.c
@@ -25,6 +25,33 @@ extern s16 D_8009D85E[];
 extern s16 D_8009D860[];
 extern s16 D_8009D862[];
 extern u8 D_801D3890[];
+// [0]: single-slot, non-scrolling widget (total=1, 1/page) - purpose not yet
+//      identified.
+// [1]: the Use tab's item list - total=0x140 (320) matches the item
+//      inventory D_8009CBE0 exactly, 10/page.
+// [2]: the Use/Arrange/Key-Items tab selector itself - total=3, wraps.
+extern Unk80026448 D_801D3DDC[];
+
+// Item-menu screen/sub-state selector. Confirmed via live RAM trace (PCSX-Redux
+// write-watch, PSX retail build) while stepping through the menu:
+//   0 = Use/Arrange/Key-Items tab selector
+//   1 = Use (item list)
+//   2 = item selected within Use (target/confirm step)
+//   3 = Key Items
+//   4 = Arrange
+// Written by func_801D131C (initial tab pick: 1/3/4) and func_801D1A6C
+// (cancel back to selector: 0; cancel out of item-select: back to 1) -
+// NOT func_801D0E80, which is a separate on-enter routine unrelated to this
+// state (see D_800493A8 in src/main/ovl.c, where func_801D0E80 is reached
+// from 8 different screen-entry slots).
+typedef enum {
+    ITEMMENU_SCREEN_SELECTOR = 0,
+    ITEMMENU_SCREEN_USE = 1,
+    ITEMMENU_SCREEN_ITEM_SELECTED = 2,
+    ITEMMENU_SCREEN_KEY_ITEMS = 3,
+    ITEMMENU_SCREEN_ARRANGE = 4,
+} ItemMenuScreen;
+extern s32 D_801D3E48;
 extern u8 D_801D3E60[];
 
 // Likely plays a menu sound effect: loads a sound command (0x30) and the sound
@@ -379,7 +406,23 @@ static void ArrangeItems(s32 mode) {
     }
 }
 
-INCLUDE_ASM("asm/us/menu/nonmatchings/itemmenu", func_801D0BA0);
+void func_801D031C(void);
+
+// exported, see 800493A8
+// Configures 3 widgets (D_801D3DDC[0..2], see Unk80026448 and the comment on
+// its extern decl for what each backs) and defaults the item-menu to the Use
+// tab, then continues in func_801D031C. That default is later overwritten by
+// func_801D131C if the player picks Arrange or Key Items instead, or by
+// func_801D1A6C if they back out to the tab selector (see ItemMenuScreen).
+// Reached from src/main/ovl.c's D_800493A8 per-screen entry table for
+// several item-menu pages, called out of func_800230C4 in src/main/1255C.c.
+void func_801D0BA0(void) {
+    D_801D3E48 = ITEMMENU_SCREEN_USE;
+    func_80026448(&D_801D3DDC[0], 0, 0, 3, 1, 0, 0, 3, 1, 0, 0, 1, 0, 0);
+    func_80026448(&D_801D3DDC[1], 0, 0, 1, 0xA, 0, 0, 1, 0x140, 0, 0, 0, 0, 0);
+    func_80026448(&D_801D3DDC[2], 0, 0, 1, 3, 0, 0, 1, 3, 0, 0, 0, 1, 0);
+    func_801D031C();
+}
 
 // True if the two adjacent record fields for entry arg0 are equal.
 s32 func_801D0CAC(s32 arg0) {


### PR DESCRIPTION
Configures 3 list widgets used by the item menu and initializes the screen/state selector to its default value. Symbolizes the function in src/main/ovl.c per-screen dispatch table (was a raw address literal) and documents the confirmed values of the state selector.