### PR TITLE
Decompile 3 world.c functions.

### DIFF
--- a/src/world/world.c
+++ b/src/world/world.c
@@ -1657,7 +1657,9 @@ INCLUDE_ASM("asm/us/world/nonmatchings/world", func_800ADA64);
 
 INCLUDE_ASM("asm/us/world/nonmatchings/world", func_800ADB30);
 
-INCLUDE_ASM("asm/us/world/nonmatchings/world", func_800ADC3C);
+void func_800ADC3C(VECTOR* arg0) {
+    D_8010AE34 = *arg0;
+}
 
 void func_800ADC70(void) { D_8010AE54 = 0; }
 

--- a/src/world/world.c
+++ b/src/world/world.c
@@ -1657,9 +1657,7 @@ INCLUDE_ASM("asm/us/world/nonmatchings/world", func_800ADA64);
 
 INCLUDE_ASM("asm/us/world/nonmatchings/world", func_800ADB30);
 
-void func_800ADC3C(VECTOR* arg0) {
-    D_8010AE34 = *arg0;
-}
+void func_800ADC3C(VECTOR* arg0) { D_8010AE34 = *arg0; }
 
 void func_800ADC70(void) { D_8010AE54 = 0; }
 
@@ -2436,7 +2434,15 @@ void func_800BB9A0(u8 arg0) {
 
 INCLUDE_ASM("asm/us/world/nonmatchings/world", func_800BB9D0);
 
-INCLUDE_ASM("asm/us/world/nonmatchings/world", func_800BBA0C);
+u8 func_800BBA0C(void) {
+    u8 var_a0;
+
+    var_a0 = 0;
+    if (&D_801163E0 < D_801163E8)
+        var_a0 = D_801163E8[-1];
+
+    return var_a0;
+}
 
 static void func_800BBA34(s8 arg0) { D_801163E0 = arg0; }
 

--- a/src/world/world.c
+++ b/src/world/world.c
@@ -2432,7 +2432,13 @@ void func_800BB9A0(u8 arg0) {
     }
 }
 
-INCLUDE_ASM("asm/us/world/nonmatchings/world", func_800BB9D0);
+u8 func_800BB9D0(void) {
+    if (&D_801163E0 >= D_801163E8)
+        return 0;
+
+    D_801163E8 = D_801163E8 - 1;
+    return D_801163E8[0];
+}
 
 u8 func_800BBA0C(void) {
     u8 var_a0;

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -264,6 +264,7 @@ extern s32 D_8010AE24;
 extern s32 D_8010AE28;
 extern s32 D_8010AE2C;
 extern s32 D_8010AE30;
+extern VECTOR D_8010AE34;
 extern s32 D_8010AE54;
 extern s32 D_8010AE58;     // WM RNG index
 extern u8 D_8010AE5C[521]; // WM RNG Buffer


### PR DESCRIPTION
Decompiled three functions in world.c:

func_800ADC3C
func_800BB9D0
func_800BBA0C

Added D_8010AE34 as a VECTOR to world.h based on inferred variable type from caller of func_800ADC3C: func_800BBD20. func_800ADC3C does a 16-byte copy which is aligned with VECTOR struct layout.