### PR TITLE
battle: decompile func_800A4350 (queued-action push)

### DIFF
--- a/src/battle/battle.c
+++ b/src/battle/battle.c
@@ -17,6 +17,10 @@ const u8 D_800A0004[] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x2E, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00};
+// opcode-byte program for func_800A1798's dispatch loop: a 0x1F-delimited
+// stream of per-command opcode sequences, sliced by D_800F38AC[cmdIndex]
+// (see func_800A283C) into per-command runs; each byte indexes D_800E7B28
+// (function-pointer table) for func_800A1798 to jalr through in order
 const u8 D_800A0098[] = {
     0x1F, 0x0E, 0x09, 0x1F, 0x00, 0x0C, 0x09, 0x1F, 0x01, 0x0C, 0x09, 0x1F,
     0x02, 0x0D, 0x09, 0x1F, 0x1E, 0x09, 0x1F, 0x0A, 0x16, 0x09, 0x1F, 0x1D,
@@ -34,6 +38,13 @@ const s32 D_800A010C[] = {2, 22, 3, 23, 4};
 // entrypoint
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800A1158);
 
+// per-command opcode dispatcher: reads cmdIndex from the turn context
+// (D_80063014->unkC), looks up its opcode-sequence start via
+// D_800F38AC[cmdIndex] into D_800A0098, then for each byte until the 0x1F
+// delimiter, jalr's through D_800E7B28[opcode]. After each call, checks
+// D_80062F14 -- if it goes >= 0 the whole sequence aborts immediately
+// (handler requested a suspend, e.g. to wait on an animation), otherwise
+// continues to the next opcode byte
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800A1798);
 
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800A22C0);
@@ -274,7 +285,38 @@ void func_800A3E98(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4) {
 
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800A3ED0);
 
-INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800A4350);
+void func_800A4350(s16 actorId, s16 cmdIndex, s16 attackIndex, u16 targetMask) {
+    QueuedAction* entry;
+
+    if (D_800F39D8 == ((D_800F39DC + 1) & 0xF)) {
+        return;
+    }
+
+    entry = &D_800F3958[D_800F39DC];
+    entry->priority = (cmdIndex == CMD_LIMIT) ? 5 : 6;
+    entry->actorId = actorId;
+    entry->cmdIndex = cmdIndex;
+    entry->attackIndex = attackIndex;
+    entry->targetMask = targetMask;
+
+    // The three inventory-consuming commands all get this extra call --
+    // compiles to retail's exact branch shape only as a switch (GCC's
+    // binary-search lowering for these 3 sparse case values: pivot on
+    // CMD_THROW, then a cmdIndex<9 range split between CMD_ITEM and
+    // CMD_W_ITEM), not as a flat "||" chain.
+    switch (cmdIndex) {
+    case CMD_THROW:
+    case CMD_ITEM:
+    case CMD_W_ITEM:
+        func_800A5660(actorId, attackIndex);
+        break;
+    }
+
+    func_800A4D88(func_800A44D8(actorId));
+    D_800F5F44.D_800F7DAC &= ~(1 << actorId);
+    D_800F5F44.D_800F7DC2 |= 1 << actorId;
+    D_800F39DC = (D_800F39DC + 1) & 0xF;
+}
 
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800A4480);
 
@@ -308,6 +350,17 @@ s32 func_800A4A80(void) {
 
 void func_800A4ACC(s16 arg0, u16 arg1) { func_8001726C(arg0, arg1); }
 
+// opcode 0x14 handler (D_800E7B28[0x14]): spins on func_800B6D6C() until
+// status bit D_800F9DA4 & 2 clears. Not itself a damage dealer -- injecting
+// cmdIndex 0x23 (single-opcode sequence: just this one) produced ~3.1%
+// max-HP damage, but func_800B6D6C (still nonmatching, battle1 overlay) is
+// just a generic drainer for the D_80163798 event queue (HP-counter ticks,
+// status-icon show/hide, sound cues -- see its own comment in battle1.c),
+// gated one-per-frame on D_800F7DE4 which func_800B7FDC sets. So this
+// opcode is "wait for already-queued visual/counter effects to finish",
+// not the source of the damage -- whatever queues an HP-tick entry into
+// D_80163798 before this opcode runs is the real damage source, still
+// untraced
 void func_800B6D6C();
 void func_800A4AF4(void) {
     while (D_800F9DA4 & 2) {
@@ -860,6 +913,14 @@ INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800AD5E8);
 
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800AD73C);
 
+// multi-target damage-reduction formula, s32 func_800AD804(s32 damage, s32
+// fullDamage): if fullDamage is false, it still gets forced true when
+// unkB8 < 2 (single target) or unk50 & 0x80 is set (the exemption bit
+// documented on unk50's seed at func_800A8D18/func_800A8D60 above); then
+// if unkAC != 0 (hit-sequence position, see func_800A8E54) returns
+// damage>>1, else returns damage unchanged when fullDamage else damage/3
+// (magic-number signed divide) -- this is the classic "multi-target hits
+// deal reduced per-target damage" mechanic
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800AD804);
 
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800AD890);

--- a/src/battle/battle1.c
+++ b/src/battle/battle1.c
@@ -216,6 +216,28 @@ INCLUDE_ASM("asm/us/battle/nonmatchings/battle1", func_800B677C);
 
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle1", func_800B6B98);
 
+// drains D_80163798 (12-byte entries, -1-terminated, index D_801590E0), one
+// entry per call, dispatched by a type byte (0-5, jtbl_800A05FC) via m2c
+// structural read (not yet decompiled):
+//   0 callback-driven step (func_800BC04C(&func_800C494C)), immediate
+//   1 gated on D_800F7DE4: walks a linked status list (D_800FA9D0/1/2),
+//     looks like "hide next status icon" (sets D_800FA6D4/D_80161EEC/
+//     D_800F99E8 icon slots, or 0xF when the list is exhausted)
+//   2 func_800C5C18(4 entry fields), immediate -- shape matches a sound cue
+//   3 gated on D_800F7DE4: same linked-list shape as case 1, opposite flag
+//     direction -- looks like "show next status icon"
+//   4 gated on D_800F7DE4: HP-counter tick-animation init -- writes to PS1
+//     scratchpad (0x1F800004/8), computes abs(diff)/entryField, stores
+//     start/target/increment into a D_80162978 slot (allocated via
+//     func_800BBEAC)
+//   5 immediate: sets a per-actor "step complete" flag, conditionally
+//     copies animation-state fields
+// D_800F7DE4 (the gate for cases 1/3/4) is set once per frame by
+// func_800B7FDC below, once all actor slots are ready -- so this function
+// is a generic "process the next queued visual/counter effect, one per
+// frame" drainer, not itself the source of any particular command's
+// damage/effect. See func_800A4AF4's comment in battle.c: opcode 0x14 just
+// spins this to drain whatever's already queued
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle1", func_800B6D6C);
 
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle1", func_800B7764);
@@ -237,6 +259,12 @@ static void func_800B7F6C(void) {
 
 void func_800B7FB4(void) { D_801518DC = func_80034B44(); }
 
+// per-frame tick: pumps the GPU ordering-table draw lists, runs render/vsync,
+// drains the action-queue ring buffer (func_800A3ED0 -- see the queue-push
+// writeup), and sets D_800F7DE4 = 1 exactly once per frame once every actor
+// slot is ready and D_80162080 (a per-frame counter) reaches 0. func_800B6D6C
+// gates several of its event-queue steps on this flag, effectively waiting
+// for "the next frame is ready" before consuming a queued effect
 static void func_800B7FDC(void) {
     s32 i;
 

--- a/src/battle/battle_private.h
+++ b/src/battle/battle_private.h
@@ -190,6 +190,68 @@ typedef struct {
     /* 0x70 */ s32 D_80151270;
 } Unk80151200; // size:0x74
 
+// Confirmed live via PCSX-Redux (exec breakpoint on func_800A4350, one command
+// at a time, plus direct cmdIndex injection for the remaining gaps). "All"-
+// linked materia (Steal-All, Sense-All, etc) reuse their base command's
+// cmdIndex -- targetMask changes, not cmdIndex. 0x0E-0x10 and past 0x1B are
+// unused/no-op (injected directly, no visible effect and not reachable via
+// any known menu path). 0x11 forces a melee attack ignoring weapon range
+// (injected on Barret with a long-range weapon -- he closed to melee instead
+// of shooting), not reachable via any menu path either -- possibly an
+// internal command for a status-forced attack (Berserk?), unconfirmed.
+typedef enum {
+    CMD_ATTACK = 0x01,
+    CMD_MAGIC = 0x02,
+    CMD_SUMMON = 0x03,
+    CMD_ITEM = 0x04,
+    CMD_STEAL = 0x05,
+    CMD_SENSE = 0x06,
+    CMD_COIN = 0x07,
+    CMD_THROW = 0x08,
+    CMD_MORPH = 0x09,
+    CMD_DEATHBLOW = 0x0A,
+    CMD_MANIPULATE = 0x0B,
+    CMD_MIME = 0x0C,
+    CMD_ENEMY_SKILL = 0x0D,
+    CMD_MELEE_ATTACK = 0x11, // ignores weapon range; not player-menu-reachable?
+    CMD_CHANGE = 0x12,
+    CMD_DEFEND = 0x13,
+    CMD_LIMIT = 0x14, // priority-5 special case in func_800A4350
+    CMD_W_MAGIC = 0x15,
+    CMD_W_SUMMON = 0x16,
+    CMD_W_ITEM = 0x17,
+    CMD_SLASH_ALL = 0x18, // materia-granted Attack-command replacement
+    CMD_2X_CUT = 0x19,    // materia-granted Attack-command replacement
+    CMD_FLASH = 0x1A,     // materia-granted Attack-command replacement
+    CMD_4X_CUT = 0x1B,    // materia-granted Attack-command replacement
+    CMD_NONE = 0xFF,      // enemy attack / not a player-menu command
+} BattleCommand;
+
+// Queued-action entry, matches
+// https://wiki.ffrtt.ru/index.php/FF7/Battle/Battle_Mechanics action-queue
+// layout exactly (priority/queue-pos/actorId/cmdIndex/attackIndex/targetMask).
+// D_800F3958 is a 16-entry ring buffer of these (D_800F39D8 read idx,
+// D_800F39DC write idx); the wiki describes up to 64 queued actions, so this
+// may be a smaller staging ring rather than the full logical queue --
+// unconfirmed. Drain chain: func_800A3ED0 drains this ring into a 64-slot
+// priority table (func_800A3D4C), which func_800A23E0 drains in priority
+// order into func_800A1798, which runs the command as a byte-coded sequence
+// of opcodes (D_800F38AC/D_800A0098/D_800E7B28), not a single switch on
+// cmdIndex. Full writeup: ff7-re/reference/BATTLE_COMMAND_QUEUE.md
+typedef struct {
+    /* 0x0 */ u8
+        priority; // 0=limits/counters, 6=player spells (see func_800A4350)
+    /* 0x1 */ u8
+        queuePos; // position within priority band; not set by func_800A4350
+    /* 0x2 */ u8 actorId;
+    /* 0x3 */ s8 cmdIndex; // BattleCommand, stored raw (not the enum type --
+                           // keeps this struct's confirmed 0x8-byte layout)
+    /* 0x4 */ s16 attackIndex; // command-dependent: spell id for CMD_MAGIC,
+                               // damage dealt for CMD_COIN, skill id for
+                               // CMD_ENEMY_SKILL, etc -- not a uniform lookup
+    /* 0x6 */ u16 targetMask;
+} QueuedAction; // size:0x8
+
 typedef struct {
     s32 unk0;
     s32 unk4;
@@ -201,6 +263,12 @@ typedef struct {
     /* 0x04 */ u8 unk4[0x64];
 } Unk800F83E4; // size:0x68
 
+extern u8 D_800708C8[]; // kernel-region table, 0x1C-byte rows, indexed by
+                        // attack/effect id
+extern u8 D_800708D0[]; // kernel-region table, 0x1C-byte rows, indexed by
+                        // attack/effect id
+extern u8 D_8009D954[]; // per-actor sub-table, 0x440 stride, 8-byte rows keyed
+                        // by effect id
 extern s32 D_800E7A38;
 extern u8 D_800E7A48[0x10];
 extern s8 D_800E7A58[];
@@ -256,6 +324,9 @@ extern s32 D_800F3944;
 extern s32 D_800F3948;
 extern s32 D_800F3950;
 extern s32 D_800F3954;
+extern QueuedAction D_800F3958[16];
+extern s32 D_800F39D8; // read index into D_800F3958
+extern s32 D_800F39DC; // write index into D_800F3958
 extern s32 D_800F39E0;
 extern s32 D_800F39E4;
 extern s32 D_800F39EC;
@@ -367,7 +438,7 @@ extern s8 D_80166F58;
 extern s8 D_80166F64;
 extern u8 D_80166F68;
 
-void func_800A4350(u8, u8, s16, u16);
+void func_800A4350(s16, s16, s16, u16);
 void func_800A8E84(s32);
 s32 func_800B3030(s32);
 void func_800B4794(void);


### PR DESCRIPTION
Adds the QueuedAction struct and BattleCommand enum, and documents (as comments only, no behavior change) the opcode dispatch loop in func_800A1798, the opcode-table layout in D_800A0098, the multi-target damage-reduction formula in func_800AD804, and the event-queue drain in func_800B6D6C/func_800B7FDC (ongoing discovery)