### PR TITLE
world: decompile func_800BBD20, decompile func_800A9334

### DIFF
--- a/src/world/world.c
+++ b/src/world/world.c
@@ -2534,7 +2534,129 @@ void func_800BBC4C(void) {
 
 static void func_800BBD0C(void) { D_801163D4 = 1; }
 
-INCLUDE_ASM("asm/us/world/nonmatchings/world", func_800BBD20);
+/*?*/ void func_800A9334(s32); // extern
+
+void func_800BBD20(s32 arg0) {
+    VECTOR sp10;
+    VECTOR sp20;
+    s16 temp_v0;
+    s32 temp_s0;
+    s32 temp_s1;
+    s32 temp_s2;
+    s32 temp_s4;
+    s32 var_v0;
+
+    temp_s2 = func_800A9174() == 3;
+    if (D_801163D8 != 0) {
+        D_801163D8 -= 1;
+        return;
+    }
+
+    if ((func_800A369C() == 0) && (func_800A1DE0() != 3)) {
+        temp_s4 = func_8001C8D4();
+        if ((D_801163D4 == 0) && (arg0 == 1))
+            func_800BBA5C();
+        else if (func_800A21A4() != 0) {
+            var_v0 = func_800A9240() == 0 ? temp_s4 & 0x40 : temp_s4 & 0xF040;
+            if ((var_v0 == 0) && (D_801163DC - 1 < 0xEU) &&
+                ((func_800A91A4(0x2000) == 0) || (func_800A9A44() == 0x12)))
+                func_800BBC4C();
+            else
+                goto block_15;
+        } else {
+        block_15:
+            if (D_801163D4 == 1)
+                D_801163D4 = 2;
+            else if (D_801163D4 == 2) {
+                D_801163D4 = 0;
+                func_800A90EC();
+                temp_s1 = func_800A9154();
+                func_800AA098(&sp10);
+                func_800AA128(&sp20);
+                func_800A2108(1, 2);
+                if ((sp10.vx != sp20.vx) || (sp10.vz != sp20.vz)) {
+                    func_800B7C58();
+                    if (temp_s2 != 0) {
+                        func_800A98A4(0);
+                        func_800AB8EC(0);
+                    }
+                    func_800AA1B8();
+                    func_800A1DD0(0);
+                    if ((temp_s1 == 5) && (func_800A98E4() != 0))
+                        func_800A98A4(0);
+                    else {
+                        if (temp_s1 == 4)
+                            func_800AB8EC(0);
+
+                        func_800AB988(temp_s1, 5);
+                        if (temp_s1 == 4)
+                            func_800AB8EC(1);
+
+                        if (func_800A929C() != 0) {
+                            temp_v0 = func_800AE47C(&sp20, &sp10) - 0x400;
+                            func_800A9480(temp_v0);
+                            func_800BB9D0();
+                            func_800A8E50();
+                            if (temp_s1 < 0x29)
+                                func_800A9110();
+
+                            func_800AA2E4(2);
+                            func_800A9480(temp_v0);
+                            func_800B63F0(1);
+                            func_800A2108(0, 6);
+                            if (temp_s1 == 4)
+                                func_800A82DC();
+                            else if (temp_s1 >= 0x29) {
+                                func_800A993C(func_800B79B8());
+                                func_800A9110();
+                            }
+                            func_800ADC3C(&sp10);
+                        } else {
+                            func_800A8A1C();
+                            temp_s0 = func_800BB9D0() & 0xFF;
+                            if (func_800A92F8(temp_s0) != 0) {
+                                func_800A9334(func_800BBA0C() & 0xFF);
+                                func_800A9110();
+                                func_800A8A1C();
+                                func_800A9334(temp_s0);
+                                func_800A8CE4();
+                            } else {
+                                func_800A9334(temp_s0);
+                                func_800A9110();
+                                if (temp_s2 != 0)
+                                    func_800BCA48();
+                            }
+                            func_800A9DB4(&sp10);
+                            if (func_800A9240() != 0)
+                                func_800B63F0(2);
+                            else
+                                func_800B63F0(1);
+
+                            if (temp_s1 == 6)
+                                func_800B65E0(-0x1EC);
+                            else if (temp_s1 == 5)
+                                func_800B65E0(-0x1ED);
+
+                            func_800A6994(&sp10, 1);
+                        }
+                    }
+                } else {
+                    if ((func_800A9174() == 3) || (func_800A9174() == 4))
+                        func_800AB8EC(0);
+
+                    if ((temp_s2 != 0) ||
+                        ((func_800A9174() == 5) && (func_800A98E4() != 0)))
+                        func_800A368C(1);
+                }
+            }
+        }
+        if ((temp_s4 & 0x40) != 0) {
+            D_801163DC += 1;
+            return;
+        }
+        D_801163DC = 0;
+    }
+}
 
 static s32 func_800BC1AC(void) { return D_801163D4; }
 

--- a/src/world/world.c
+++ b/src/world/world.c
@@ -4,10 +4,12 @@
 void func_800AA0E0(VECTOR* arg0);
 s32 func_800ADFC0(void);
 static s32 func_800B0800(void);
+static s32 func_800B716C(void);
 static s32 func_800B7B2C(void);
 s32 func_800B7B3C(void);
 void func_800BC9E8(s16 arg0);
 s16 func_800BCA38(void);
+void func_800BCA48(void);
 
 const char D_800A0000[] = "NEW  ";
 static const char D_800A0008[] = "OLD  ";
@@ -761,7 +763,56 @@ static const s32 D_800A01E0[] = {0, 0};
 static const s32 D_800A01E8[] = {0, 0, 0, 0};
 
 // TODO: this -> 800b624c, 800b58f8, 800ada64
-INCLUDE_ASM("asm/us/world/nonmatchings/world", func_800A9334);
+/*?*/ void func_800ADA64(WorldActor*); // extern
+/*?*/ void func_800B58F8(u8*, RECT*);  // extern
+
+void func_800A9334(s32 arg0) {
+    RECT rect;
+
+    if (D_8010AD3C != NULL) {
+        D_8010AD3C->actorType = (u8)arg0;
+        switch (arg0) {
+        case 5:
+        case 13:
+        case 28:
+            break;
+        case 3:
+            if (func_800B716C() == 0)
+                D_8010AD3C->riding = &D_80109E54;
+
+            rect.x = 0x18;
+            rect.y = 0x48;
+            rect.w = 0xE;
+            rect.h = 0x1F;
+            break;
+        case 10:
+            rect.x = 0x90;
+            rect.w = 0xF;
+            rect.h = 0xF;
+            rect.y = 0;
+            D_8010AD3C->unk58 = 0x80;
+            break;
+        case 11:
+            rect.y = 0x38;
+            rect.w = 0x17;
+            rect.h = 0x2F;
+            rect.x = 0;
+            D_8010AD3C->unk58 = 0x20;
+            break;
+        case 4:
+            func_800B624C(4, 0);
+            /* fallthrough */
+        default:
+            rect.x = 0x18;
+            rect.y = 0x38;
+            rect.w = 0xF;
+            rect.h = 0xF;
+            D_8010AD3C->unk58 = 0x20;
+        }
+        func_800B58F8(D_8010AD3C->unk90, &rect);
+        func_800ADA64(D_8010AD3C);
+    }
+}
 
 void func_800A9480(u16 arg0) {
     if (D_8010AD3C != NULL) {
@@ -2533,8 +2584,6 @@ void func_800BBC4C(void) {
 }
 
 static void func_800BBD0C(void) { D_801163D4 = 1; }
-
-/*?*/ void func_800A9334(s32); // extern
 
 void func_800BBD20(s32 arg0) {
     VECTOR sp10;

--- a/src/world/world.c
+++ b/src/world/world.c
@@ -1,9 +1,12 @@
 //! PSYQ=3.3 CC1=2.6.3 g=false gcoff=false
 #include "world.h"
 
+void func_800A9480(s16 arg0);
 void func_800AA0E0(VECTOR* arg0);
+void func_800ADA64(WorldActor*);
 s32 func_800ADFC0(void);
 static s32 func_800B0800(void);
+void func_800B58F8(u8*, RECT*);
 static s32 func_800B716C(void);
 static s32 func_800B7B2C(void);
 s32 func_800B7B3C(void);
@@ -763,9 +766,6 @@ static const s32 D_800A01E0[] = {0, 0};
 static const s32 D_800A01E8[] = {0, 0, 0, 0};
 
 // TODO: this -> 800b624c, 800b58f8, 800ada64
-/*?*/ void func_800ADA64(WorldActor*); // extern
-/*?*/ void func_800B58F8(u8*, RECT*);  // extern
-
 void func_800A9334(s32 arg0) {
     RECT rect;
 
@@ -814,7 +814,7 @@ void func_800A9334(s32 arg0) {
     }
 }
 
-void func_800A9480(u16 arg0) {
+void func_800A9480(s16 arg0) {
     if (D_8010AD3C != NULL) {
         D_8010AD3C->direction = arg0;
         D_8010AD3C->facing = (s16)arg0;
@@ -2603,11 +2603,11 @@ void func_800BBD20(s32 arg0) {
 
     if ((func_800A369C() == 0) && (func_800A1DE0() != 3)) {
         temp_s4 = func_8001C8D4();
-        if ((D_801163D4 == 0) && (arg0 == 1))
+        if ((D_801163D4 == 0) && (arg0 == 1)) {
             func_800BBA5C();
-        else if (func_800A21A4() != 0) {
+        } else if (func_800A21A4() != 0) {
             var_v0 = func_800A9240() == 0 ? temp_s4 & 0x40 : temp_s4 & 0xF040;
-            if ((var_v0 == 0) && (D_801163DC - 1 < 0xEU) &&
+            if ((var_v0 == 0) && D_801163DC > 0 && D_801163DC < 15 &&
                 ((func_800A91A4(0x2000) == 0) || (func_800A9A44() == 0x12)))
                 func_800BBC4C();
             else

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -69,7 +69,8 @@ typedef struct WorldActor {
     /* 0x55 */ u8 horizontalSpeed;
     /* 0x56 */ u8 waitFrames;
     /* 0x57 */ u8 scriptPriority;
-    /* 0x58 */ s32 unk58;
+    /* 0x58 */ u8 unk58;
+    /* 0x59 */ s8 unk59[3];
     /* 0x5C */ s8 verticalSpeed;
     /* 0x5D */ s8 animId;
     /* 0x5E */ s8 unk5E;
@@ -240,6 +241,7 @@ extern s32 D_80109D54;
 extern s32 D_80109D58;
 extern s32 D_80109D6C;
 extern WorldActor D_80109D74[0x10]; // World map actor heap, TODO: Confirm size
+extern WorldActor D_80109E54;
 extern WorldActor* D_8010AD34;
 extern WorldActor* D_8010AD38;
 extern WorldActor* D_8010AD3C; // Active Actor


### PR DESCRIPTION
Decompiled two functions from world.c:

func_800BBD20
func_800A9334

Add D_80109E54 as a WorldActor due to its address being used to set D_8010AD3C->riding.
WorldActor's unk58 appears to be a u8 based on its usage in func_800A9334. The original assembly specifically requires a store byte instruction.