### PR TITLE
battle: decompile script-VM stack helpers func_800B1624, func_800B17F…

### DIFF
--- a/src/battle/battle.c
+++ b/src/battle/battle.c
@@ -1932,15 +1932,59 @@ INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800B141C);
 
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800B153C);
 
-INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800B1624);
+// Push `value` onto the operand stack as `size` bytes, most significant byte
+// first. Sizes above 3 (or negative) push nothing; the cases deliberately fall
+// through so that each one pushes one fewer byte than the last.
+void func_800B1624(s32 size, u32 value) {
+    switch (size) {
+    case 3:
+        D_800F4AC4->stack[--D_800F4AC4->sp] = value;
+        value >>= 8;
+    case 2:
+        D_800F4AC4->stack[--D_800F4AC4->sp] = value;
+        value >>= 8;
+    case 1:
+    case 0:
+        D_800F4AC4->stack[--D_800F4AC4->sp] = value;
+    }
+}
 
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800B16D0);
 
-INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800B17F0);
+// Pop a `size`-byte big-endian value off the operand stack. The inverse of
+// func_800B1624, and likewise falls through so each case consumes one byte.
+s32 func_800B17F0(s32 size) {
+    s32 value = 0;
+    u8 byte;
+
+    switch (size) {
+    case 3:
+        value = D_800F4AC4->stack[D_800F4AC4->sp++];
+    case 2:
+        byte = D_800F4AC4->stack[D_800F4AC4->sp++];
+        value <<= 8;
+        value |= byte;
+    case 1:
+    case 0:
+        byte = D_800F4AC4->stack[D_800F4AC4->sp++];
+        value <<= 8;
+        value |= byte;
+    }
+    return value;
+}
 
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800B18A8);
 
-INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800B1A5C);
+// Evaluate the operand at the script cursor without consuming it: run the
+// normal operand fetch, then rewind the stack pointer to where it started so
+// the operand bytes it popped stay available to the next read.
+s32 func_800B1A5C(s32 arg0) {
+    s32 sp = D_800F4AC4->sp;
+    s32 result = func_800B18A8(arg0);
+
+    D_800F4AC4->sp = sp;
+    return result;
+}
 
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800B1AA0);
 

--- a/src/battle/battle_private.h
+++ b/src/battle/battle_private.h
@@ -637,6 +637,31 @@ typedef struct {
     /* 0x12 */ u8 unk12[0x22E];
 } BattleMenuWidget; /* size: 0x240 */
 
+/* State of the battle-script VM interpreted by func_800B1D48. Operands are
+   fetched from the script buffer D_800F4AC0 at `pc` and evaluated on `stack`,
+   which grows downwards: a push predecrements `sp` before storing, a pop reads
+   at `sp` then postincrements it. Instructions address two operand slots by
+   index, hence the [2] arrays. */
+typedef struct {
+    /* 0x00 */ s32 unk0;
+    /* 0x04 */ s32 pc;
+    /* 0x08 */ s32 sp;
+    /* 0x0C */ s32 opcode;
+    /* 0x10 */ s32 unk10;
+    /* 0x14 */ s32 unk14;
+    /* 0x18 */ s32 unk18[2];
+    /* 0x20 */ s32 unk20[2];
+    /* 0x28 */ u16 unk28[2];
+    /* 0x2C */ s32 var[2][10];
+    /* variable length: indexed by `sp`, extent unconfirmed */
+    /* 0x7C */ u8 stack[1];
+} BattleScriptVm;
+
+extern u8* D_800F4AC0;
+extern BattleScriptVm* D_800F4AC4;
+
+s32 func_800B18A8(s32);
+
 void func_800A4E40(void);
 void func_800DE2B4(void);
 void func_800E08C4(s32);


### PR DESCRIPTION
…0, func_800B1A5C

Adds a BattleScriptVm struct for the object behind D_800F4AC4, the state of the battle-script VM interpreted by func_800B1D48. The layout is derived from the twelve functions in this cluster: the operand stack pointer at 0x8 indexes a byte stack at 0x7C, and the two [2] operand slots are addressed by index throughout (func_800B18A8 writes 0x18/0x20/0x28, func_800B1AA0 reads the two 0x28-byte variable banks at 0x2C and 0x54).

func_800B1624 and func_800B17F0 are the push/pop pair, both written as fall-through switches so each case moves one fewer byte. func_800B1A5C wraps func_800B18A8 to evaluate an operand without consuming it, rewinding the stack pointer afterwards.

`stack` is sized [1] rather than left as a flexible array member: the 2.6 compiler rejects the latter ("field `stack' has incomplete type") and silently drops the stores.

Used Claude Opus for the functions, but i double checked it myself and it compiles fine. 