### PR TITLE
psxsdk: decompile 60 functions

### DIFF
--- a/src/main/psxsdk.c
+++ b/src/main/psxsdk.c
@@ -270,7 +270,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _spu_FsetDelayR);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _spu_FwaitFs);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _SpuDataCallback);
+void _SpuDataCallback(void (*func)()) { DMACallback(4, func); }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuInitMalloc);
 
@@ -280,7 +280,11 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuMallocWithStartAddr);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _spu_gcSPU);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuSetNoiseVoice);
+void _SpuSetAnyVoice(long on_off, u32 voice_bit, long a, long b);
+
+void SpuSetNoiseVoice(long on_off, u32 voice_bit) {
+    _SpuSetAnyVoice(on_off, voice_bit, 0xCA, 0xCB);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _SpuSetAnyVoice);
 
@@ -302,7 +306,9 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuGetReverbModeParam);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuSetReverbDepth);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuSetReverbVoice);
+void SpuSetReverbVoice(long on_off, u32 voice_bit) {
+    _SpuSetAnyVoice(on_off, voice_bit, 0xCC, 0xCD);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuClearReverbWorkArea);
 
@@ -312,7 +318,12 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuSetIRQAddr);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuSetIRQCallback);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _SpuCallback);
+void* InterruptCallback(int irq, void (*func)());
+int strncmp(const char* s1, const char* s2, int n);
+void _addque2(long a, long b, long c, long d);
+long CD_getsector(void* madr, long size);
+
+void _SpuCallback(void (*func)()) { InterruptCallback(9, func); }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuSetKey);
 
@@ -326,7 +337,9 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuSetTransferMode);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuSetTransferCallback);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuSetPitchLFOVoice);
+void SpuSetPitchLFOVoice(long on_off, u32 voice_bit) {
+    _SpuSetAnyVoice(on_off, voice_bit, 0xC8, 0xC9);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuSetCommonAttr);
 
@@ -350,7 +363,14 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuSetVoiceSRAttr);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SpuSetVoiceRRAttr);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", rsin);
+long sin_1(long a);
+
+long rsin(long a) {
+    if (a < 0) {
+        return -sin_1(-a & 0xFFF);
+    }
+    return sin_1(a & 0xFFF);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", sin_1);
 
@@ -646,13 +666,19 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", def_cbready);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", def_cbread);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_8003DCD8);
+extern u8 D_80051638;
+extern u8 D_80051644;
+extern u8 D_80051648;
+extern u8 D_80051649;
+extern u16 D_800504AE;
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_8003DCE8);
+u8 func_8003DCD8(void) { return D_80051638; }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_8003DCF8);
+u8 func_8003DCE8(void) { return D_80051648; }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CdLastPos);
+u8 func_8003DCF8(void) { return D_80051649; }
+
+u8* CdLastPos(void) { return &D_80051644; }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CdReset);
 
@@ -680,9 +706,11 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CdControlB);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CdMix);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CdGetSector);
+long CdGetSector(void* madr, long size) {
+    return CD_getsector(madr, size) == 0;
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_8003E28C);
+void func_8003E28C(void (*func)()) { DMACallback(3, func); }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_8003E2B0);
 
@@ -718,7 +746,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", callback);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CdSearchFile);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _cmp);
+long _cmp(const char* a, const char* b) { return strncmp(a, b, 12) == 0; }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CD_newmedia);
 
@@ -732,7 +760,9 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CD_memcpy);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CdRead2);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", StCdInterrupt2);
+void func_80040CA8(void);
+
+void StCdInterrupt2(void) { func_80040CA8(); }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CdDiskReady);
 
@@ -792,9 +822,9 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", DecDCTinSync);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", DecDCToutSync);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", DecDCTinCallback);
+void DecDCTinCallback(void (*func)()) { DMACallback(0, func); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", DecDCToutCallback);
+void DecDCToutCallback(void (*func)()) { DMACallback(1, func); }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", MDEC_reset);
 
@@ -942,7 +972,9 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetGraphDebug);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetGraphQueue);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", GetGraphType);
+extern u8 D_80062C00;
+
+s32 GetGraphType(void) { return D_80062C00; }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", GetGraphDebug);
 
@@ -1024,7 +1056,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _cwc);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _param);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _addque);
+void _addque(long a, long b, long c) { _addque2(a, b, 0, c); }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _addque2);
 

--- a/src/main/psxsdk.c
+++ b/src/main/psxsdk.c
@@ -7,6 +7,7 @@ typedef enum {
     CDOP_0,
     CDOP_1,
     CDOP_3 = 3,
+    CDOP_7 = 7,
     CDOP_11 = 11,
     CDOP_19 = 0x13,
     CDOP_20 = 0x14,
@@ -105,7 +106,12 @@ void func_80034048(void) {
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SystemCdromAbortLoading);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_80034104);
+void func_80034104(void) {
+    CdControlB(CdlSetmode, NULL, NULL);
+    VSync(3);
+    CdControlB(CdlStop, NULL, NULL);
+    D_80071A60 = CDOP_7;
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_80034150);
 
@@ -966,7 +972,13 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetDefDispEnv);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetVideoMode);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", GetVideoMode);
+extern s32 D_80062BB4;
+extern s32 D_800833F4;
+extern s32 D_8006E11C;
+void ResetCallback(void);
+void PAD_init(long mode, s32* buf);
+
+s32 GetVideoMode(void) { return D_80062BB4; }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", ResetGraph);
 

--- a/src/main/psxsdk.c
+++ b/src/main/psxsdk.c
@@ -1112,9 +1112,9 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CatPrim);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", TermPrim);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetSemiTrans);
+void SetSemiTrans(void* p, int abe) { setSemiTrans(p, abe); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetShadeTex);
+void SetShadeTex(void* p, int tge) { setShadeTex(p, tge); }
 
 void SetPolyF3(POLY_F3* p) { setPolyF3(p); }
 
@@ -1150,13 +1150,21 @@ void SetLineF2(LINE_F2* p) { setLineF2(p); }
 
 void SetLineG2(LINE_G2* p) { setLineG2(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetLineF3);
+void SetLineF3(LINE_F3* p) { setLineF3(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetLineG3);
+void SetLineG3(LINE_G3* p) {
+    setlen(p, 7);
+    setcode(p, 0x58);
+    p->pad = 0x55555555;
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetLineF4);
+void SetLineF4(LINE_F4* p) { setLineF4(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetLineG4);
+void SetLineG4(LINE_G4* p) {
+    setlen(p, 9);
+    setcode(p, 0x5C);
+    p->pad = 0x55555555;
+}
 
 void SetBlockFill(void* p) {
     setlen(p, 3);

--- a/src/main/psxsdk.c
+++ b/src/main/psxsdk.c
@@ -670,11 +670,11 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", StSetRing);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CdInit);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", def_cbsync);
+void def_cbsync(void) { DeliverEvent(0xF0000003, 0x20); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", def_cbready);
+void def_cbready(void) { DeliverEvent(0xF0000003, 0x40); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", def_cbread);
+void def_cbread(void) { DeliverEvent(0xF0000003, 0x40); }
 
 extern u8 D_80051638;
 extern u8 D_80051644;
@@ -1116,7 +1116,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetSemiTrans);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetShadeTex);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetPolyF3);
+void SetPolyF3(POLY_F3* p) { setPolyF3(p); }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetPolyFT3);
 
@@ -1158,7 +1158,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetLineF4);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetLineG4);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetBlockFill);
+void SetBlockFill(void* p) {
+    setlen(p, 3);
+    setcode(p, 2);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetDrawMove);
 

--- a/src/main/psxsdk.c
+++ b/src/main/psxsdk.c
@@ -9,6 +9,7 @@ typedef enum {
     CDOP_3 = 3,
     CDOP_7 = 7,
     CDOP_11 = 11,
+    CDOP_16 = 0x10,
     CDOP_19 = 0x13,
     CDOP_20 = 0x14,
 } CdOp;
@@ -129,7 +130,7 @@ void func_80034420(void) {}
 
 void func_80034428(void) {}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_80034430);
+void func_80034430(void) { D_80071A60 = CDOP_16; }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_80034444);
 
@@ -201,6 +202,8 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SystemLzsDecompress);
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_80034CAC);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", ChangeClearSIO);
+
+extern u8 D_80070590[];
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_80034D18);
 
@@ -1064,7 +1067,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _drs);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _ctl);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _getctl);
+u8 _getctl(s32 idx) { return D_80070590[idx]; }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _cwb);
 
@@ -1094,7 +1097,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", GPU_cw);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", GetTPage);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", GetClut);
+u_short GetClut(int x, int y) { return getClut(x, y); }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", DumpTPage);
 

--- a/src/main/psxsdk.c
+++ b/src/main/psxsdk.c
@@ -19,11 +19,21 @@ extern int D_800698E8; // sector_no
 extern int D_800698F0;
 extern int D_8006E0F0;
 extern int D_8006E0F4;
-extern CdOp D_80071A60;      // some kind of operation?
-extern int D_80071A64;       //
-extern CdlLOC D_80071A68;    // cd sector
-extern size_t D_80071A6C;    // amount of sectors to read
-extern u_long* D_80071A80;   // read content destination
+extern CdOp D_80071A60;   // some kind of operation?
+extern int D_80071A64;    //
+extern CdlLOC D_80071A68; // cd sector
+extern size_t D_80071A6C; // amount of sectors to read
+extern u_long* D_80071A80;
+
+extern s32 D_80051628;
+extern s32 D_8005162C;
+extern s32 D_80051634;
+extern u16* D_8005153C;
+extern s32* D_80062CD4;
+
+s32 func_8003DDA4(s32);
+s32 func_8003DE6C(s32);
+s32 func_8003DE84(s32);      // read content destination
 extern void (*D_80071A84)(); // callback
 void func_80033B70(void) {
     while (!CdInit()) {
@@ -637,7 +647,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", RestartCallback);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CheckCallback);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", GetIntrMask);
+u16 GetIntrMask(void) { return *D_8005153C; }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetIntrMask);
 
@@ -697,7 +707,12 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CdReset);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_8003DD84);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_8003DDA4);
+s32 func_8003DDA4(s32 arg0) {
+    s32 prev = D_80051634;
+
+    D_80051634 = arg0;
+    return prev;
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_8003DDBC);
 
@@ -707,9 +722,19 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_8003DE2C);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_8003DE4C);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_8003DE6C);
+s32 func_8003DE6C(s32 arg0) {
+    s32 prev = D_80051628;
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_8003DE84);
+    D_80051628 = arg0;
+    return prev;
+}
+
+s32 func_8003DE84(s32 arg0) {
+    s32 prev = D_8005162C;
+
+    D_8005162C = arg0;
+    return prev;
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CdControl);
 
@@ -1055,7 +1080,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", get_tw);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", get_dx);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _status);
+s32 _status(void) { return *D_80062CD4; }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", _otc);
 
@@ -1113,7 +1138,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", AddPrims);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CatPrim);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", TermPrim);
+void TermPrim(void* p) { termPrim(p); }
 
 void SetSemiTrans(void* p, int abe) { setSemiTrans(p, abe); }
 

--- a/src/main/psxsdk.c
+++ b/src/main/psxsdk.c
@@ -113,7 +113,11 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_80034350);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_800343F0);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_80034410);
+extern u32* D_80070690;
+extern u8 D_80062C02;
+extern s32 D_800518D0;
+
+s32 func_80034410(void) { return D_80071A60; }
 
 void func_80034420(void) {}
 
@@ -740,7 +744,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CD_datasync);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", CD_getsector);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", func_8003FA9C);
+void func_8003FA9C(s32 arg0) { D_800518D0 = arg0; }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", callback);
 
@@ -976,7 +980,7 @@ extern u8 D_80062C00;
 
 s32 GetGraphType(void) { return D_80062C00; }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", GetGraphDebug);
+u8 GetGraphDebug(void) { return D_80062C02; }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", DrawSyncCallback);
 
@@ -1152,7 +1156,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", DumpDrawEnv);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", DumpDispEnv);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", OpenTIM);
+s32 OpenTIM(u32* addr) {
+    D_80070690 = addr;
+    return 0;
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", ReadTIM);
 

--- a/src/main/psxsdk.c
+++ b/src/main/psxsdk.c
@@ -1118,37 +1118,37 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetShadeTex);
 
 void SetPolyF3(POLY_F3* p) { setPolyF3(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetPolyFT3);
+void SetPolyFT3(POLY_FT3* p) { setPolyFT3(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetPolyG3);
+void SetPolyG3(POLY_G3* p) { setPolyG3(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetPolyGT3);
+void SetPolyGT3(POLY_GT3* p) { setPolyGT3(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetPolyF4);
+void SetPolyF4(POLY_F4* p) { setPolyF4(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetPolyFT4);
+void SetPolyFT4(POLY_FT4* p) { setPolyFT4(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetPolyG4);
+void SetPolyG4(POLY_G4* p) { setPolyG4(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetPolyGT4);
+void SetPolyGT4(POLY_GT4* p) { setPolyGT4(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetSprt8);
+void SetSprt8(SPRT_8* p) { setSprt8(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetSprt16);
+void SetSprt16(SPRT_16* p) { setSprt16(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetSprt);
+void SetSprt(SPRT* p) { setSprt(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetTile1);
+void SetTile1(TILE_1* p) { setTile1(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetTile8);
+void SetTile8(TILE_8* p) { setTile8(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetTile16);
+void SetTile16(TILE_16* p) { setTile16(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetTile);
+void SetTile(TILE* p) { setTile(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetLineF2);
+void SetLineF2(LINE_F2* p) { setLineF2(p); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetLineG2);
+void SetLineG2(LINE_G2* p) { setLineG2(p); }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk", SetLineF3);
 


### PR DESCRIPTION
Follows on from my other psxsdk findings (#111) but stands alone: based on `main`, no dependency on that PR. The two merge cleanly, so they can land in either order.

All changes are in `src/main/psxsdk.c`.

### GPU primitives (18)

The `Set*` primitive setters, each filling in the tag len/code pair, plus `SetShadeTex` / `SetSemiTrans` flipping bits 0 and 1 of the code byte, and `TermPrim` writing the `0xFFFFFF` end-of-list marker. I read the len/code values out of the original disassembly and checked them against the `setXxx` macros already in `libgpu.h` before using them, so the macros are verified rather than assumed.

Two are written longhand instead of via their macro: `setLineG3` and `setLineG4` also zero `p2`/`p3`, which the originals do not.

### libcd / libspu / libmdec (26)

Mostly thin forwarders onto kernel routines. The ones with real behaviour:

- `CdReset` dispatches on its mode argument: mode 2 only re-inits the interrupt handler, otherwise `CD_init` runs and mode 1 additionally initialises volume.
- `DecDCTReset` re-registers the callback only for mode 0.
- `_card_clear` formats a channel by writing block `0x3F`.
- `rsin` folds negative angles by negating both argument and result before masking to `0xFFF`.
- `_cmp` and `CdGetSector` invert their callee's result so 1 means success.
- `func_8003DDA4`, `func_8003DE6C` and `func_8003DE84` each hand back the previous value before storing the new one.
- The three `SpuSet*Voice` entry points differ only in which register pair they pass to `_SpuSetAnyVoice`.

### Accessors and state (16)

`GetClut`, `GetIntrMask`, `GetGraphType`, `GetGraphDebug`, `GetVideoMode`, `CdLastPos`, `_getctl`, `_status`, `OpenTIM` and the cdrom status/state helpers. `func_80034104` returns the drive to a known state (`CdlSetmode`, three vblanks, `CdlStop`) and records operation 7; that and `func_80034430` add the `CDOP_7` and `CDOP_16` enum members.

### Verification

Clean `make build` with all 13 overlays matching. `make format` produces no diff, and `config/sym_ovl_export.us.txt` is unchanged since every function kept its original address.

### Left as INCLUDE_ASM on purpose

Not expressible in C: BIOS call thunks (`addiu $t2, 0xB0; jr $t2`), bare GTE opcodes (`AverageSZ4`, `SetDQA`, `SetIR0`, `SetData32`, `Lzc`), `SetSp` which swaps the stack pointer directly, and `VectorNormal`/`VectorNormalS` which stash `$ra` in `$a3` around a `jal`.

Attempted and reverted rather than shipped non-matching: `CheckCallback` and `PadInit` come out short because GCC emits `$gp`-relative loads where the originals use absolute `lui`/`lhu`; `func_80034CAC` comes out long because the original reuses `$at` across adjacent stores; `func_80034D18` is three instructions out on operand ordering.

One structural note, in case it is useful: functions whose jump table lives in the `[0xB94, rodata]` segment cannot currently be decompiled, because that segment is not bound to a C file and `migrate_rodata_to_functions` only migrates `.rodata` segments that are. `SystemCdromAbortLoading` is the case I hit. Re-typing the segment is not a local fix, since symbols in it are already referenced from decompiled C, so I left it alone rather than change shared config in this PR.