### PR TITLE
batini: decompile 8 functions (item list, ATB seed, command/materia setup)

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -821,7 +821,7 @@ extern u16 g_FieldScriptPC[48]; // program counters for active entity scripts
 extern u8 D_8008325C[];         // per-model default animation id (DFANM)
 extern u8 g_WindowToEntity[4];
 extern WindowData g_WindowData[4];
-extern u8 D_8008326C;
+extern u8 D_8008326C[4];
 extern s32 D_80083338;
 extern u8 g_FieldScriptSyncState[48][8]; // sync states of entity scripts per
                                          // priority level

--- a/include/game.h
+++ b/include/game.h
@@ -409,6 +409,14 @@ typedef struct {
     s32 unk25C;
 } Unk800A8D04; // size: ???
 
+// one equipped-materia slot of a party member (Unk8009D84C.unk108)
+typedef struct {
+    u8 unk0; // attack id, biased by the slot's bank; 0xFF = empty
+    u8 unk1;
+    u8 unk2;
+    u8 unk3[5];
+} Unk8009D954; // size: 0x8
+
 // seems to be related to a party member during battle
 typedef struct {
     s32 unk0;
@@ -429,11 +437,21 @@ typedef struct {
     s8 unk21;
     s8 unk22;
     s8 unk23;
-    u8 unk24[0x28];
-    u8 un4C[4][6];
-    u8 un64[0x48];
+    u8 unk24[0x18];
+    u16 unk3C;
+    u8 unk3E[6];
+    s32 unk44;
+    s32 unk48;
+    u8 un4C[16][6];
     u8 unAC[4];
-    u8 unB0[0x390];
+    u8 unB0[0x58];
+    Unk8009D954 unk108[0x60];
+    u8 un408;
+    u8 un409[7];
+    u8 un410;
+    u8 un411[7];
+    u16 un418;
+    u8 un41A[0x26];
 } Unk8009D84C; // size: 0x440
 
 typedef struct {

--- a/src/battle/batini.c
+++ b/src/battle/batini.c
@@ -53,7 +53,74 @@ void func_801B0490(s32 sceneID) {
     }
 }
 
-INCLUDE_ASM("asm/us/battle/nonmatchings/batini", func_801B0668);
+extern u16 D_8016375A;
+extern u16 D_8009D864[][0x220]; // stride 0x440, one per Unk8009D84C record
+u16 func_800B2F50(void);        // random, 16-bit
+
+// Rolls the initial ATB timer of every present combatant and writes it into
+// D_800F5BBC. The battle type (D_800F7DC8) then biases those timers: a
+// preemptive-style opening zeroes the party's, an ambush pushes it towards the
+// enemies, and a Battle Square opening (setup flag 8) overrides both.
+void func_801B0668(void) {
+    s32 timer[10];
+    s32 presentMask;
+    s32 max;
+    s32 val;
+    s32 t;
+    s32 i;
+
+    presentMask = D_8016375A;
+    max = 0;
+    for (i = 0; i < 10; i++) {
+        D_800F5BBC[i][0] = 0;
+        val = 0;
+        if ((presentMask >> i) & 1) {
+            val = func_800B2F50() >> 1;
+            if (max < val) {
+                max = val;
+            }
+        }
+        timer[i] = val;
+    }
+    for (i = 0; i < 10; i++) {
+        if ((presentMask >> i) & 1) {
+            switch (D_800F5F44.D_800F7DC8) {
+            case 0:
+            case 5:
+                t = timer[i] + 0xE000;
+                timer[i] = t - max;
+                break;
+            case 2:
+            case 4:
+                if (i < 4) {
+                    timer[i] = 0;
+                } else {
+                    t = timer[i] + 0xF000;
+                    timer[i] = t - max;
+                }
+                break;
+            default:
+                if (i < 4) {
+                    timer[i] = 0xFFFE;
+                } else {
+                    timer[i] = timer[i] >> 3;
+                }
+                break;
+            }
+            if (g_BattleState.setupFlags & 8) {
+                if (i < 3) {
+                    timer[i] = 0xFFFE;
+                } else {
+                    timer[i] = 0;
+                }
+            }
+            D_800F5BBC[i][0] = timer[i];
+        }
+    }
+    for (i = 0; i < 3; i++) {
+        D_8009D864[i][0] = D_800F5BBC[i][0];
+    }
+}
 
 void func_801B085C(s32 arg0) {
     D_800F5F44.D_800F7DA6 = 0x10000 / ((arg0 * 480 / 256 + 0x78) * 2);
@@ -61,7 +128,88 @@ void func_801B085C(s32 arg0) {
 
 INCLUDE_ASM("asm/us/battle/nonmatchings/batini", func_801B08C0);
 
-INCLUDE_ASM("asm/us/battle/nonmatchings/batini", func_801B0F08);
+// The per-party work area at 0x800F5BB8: the turn state, the three party
+// records (D_800F5E60) and their setup config (D_800F5EFC) are one object, so
+// BATINI reaches all three off a single base.
+typedef struct {
+    /* 0x00 */ u8 unk0;
+    /* 0x01 */ u8 unk1;
+    /* 0x02 */ u8 unk2;
+    /* 0x03 */ u8 unk3;
+    /* 0x04 */ u8 unk4[0xA];
+    /* 0x0E */ u16 unkE;
+    /* 0x10 */ u8 unk10[4];
+    /* 0x14 */ s32 unk14;
+} Unk800F5EFC; // size:0x18
+
+typedef struct {
+    /* 0x000 */ Unk800AF470 turn[10];
+    /* 0x2A8 */ Unk800F5E60 party[3];
+    /* 0x344 */ Unk800F5EFC setup[3];
+} BattleWork; // size:0x38C
+
+extern BattleWork g_CombatantTurnState;
+extern SavePartyMember D_8009C738[];
+void func_801B1598(s32 slot, s32 accessory);
+void func_801B11BC(s32 slot);
+void func_800A4BA4(s32 slot);
+s32 func_801B1734(s32 slot);
+
+// Seeds the three live party slots from the save data: finds each slot's
+// party member record, copies HP/MP and the derived battle stats across, then
+// applies the equipped accessory, the command list and the row/limit setup.
+void func_801B0F08(void) {
+    Unk800F5E60* party;
+    Unk8009D84C* rec;
+    Unk800F83E0* c;
+    Unk800AF470* t;
+    Unk800F5EFC* setup;
+    SavePartyMember* m;
+    s32 id;
+    s32 i;
+    s32 j;
+
+    for (i = 0; i < 3; i++) {
+        t = &g_CombatantTurnState.turn[i];
+        party = &g_CombatantTurnState.party[i];
+        rec = &D_8009D84C[i];
+        c = &g_BattleState.combatant[i];
+        setup = &g_CombatantTurnState.setup[i];
+        id = D_8009CBDC[i];
+        if (id != 0xFF) {
+            for (j = 0; j < 9; j++) {
+                m = &D_8009C738[j];
+                if (m->char_id == id) {
+                    c->unk9 = m->level;
+                    c->curHP = m->hp_cur;
+                    c->unk28 = m->mp_cur;
+                    t->unk3C = c->curHP;
+                    t->unk3E = c->unk28;
+                    func_801B18F8(rec, party, c);
+                    t->unk34 = rec->unk48;
+                    setup->unkE = rec->un418 | rec->unk3C;
+                    setup->unk14 = rec->unk44;
+                    setup->unk3 = rec->un410;
+                    setup->unk0 = rec->un408;
+                    t->unk29 &= 0xFD;
+                    if (rec->unk23 & 4) {
+                        setup->unk0 &= 0xDF;
+                    }
+                    if (!(setup->unk0 & 0x20)) {
+                        t->unk29 |= 2;
+                    }
+                    func_801B1598(i, m->accessory);
+                    func_801B11BC(i);
+                    func_800A4BA4(i);
+                    if (func_801B1734(i) == 0) {
+                        func_800B108C(i);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}
 
 extern void func_800A6000(s32, s32, s32);
 
@@ -76,7 +224,76 @@ void func_801B1120(void) {
     }
 }
 
-INCLUDE_ASM("asm/us/battle/nonmatchings/batini", func_801B11BC);
+extern u8 D_800707C5[][8];    // command table, 8-byte stride
+extern u8 D_800708D0[][0x1C]; // attack table, 0x1C stride
+extern u8 D_800F5EFC[][0x18]; // per-slot formation-setup config
+extern u8 D_800F5BE1[][0x44]; // same records as D_800F5BBC
+
+// Fixes up party member arg0's battle command list: each of the 16 command
+// slots gets its target flags from the command table (falling back to the
+// formation setup), with extra flags for the Enemy Skill / W- commands, and
+// unk21 ends up as the number of command rows in use. The second pass clears
+// the "usable" byte of every equipped materia whose attack is not flagged
+// battle-usable.
+void func_801B11BC(s32 arg0) {
+    Unk8009D84C* e;
+    s32 cmd;
+    s32 flags;
+    s32 id;
+    s32 i;
+
+    e = &D_8009D84C[arg0];
+    e->unk21 = 1;
+    for (i = 0; i < 16; i++) {
+        flags = 0xFF;
+        cmd = e->un4C[i][0];
+        if (cmd != 0xFF) {
+            flags = D_800707C5[cmd][0];
+            if (flags == 0xFF) {
+                flags = D_800F5EFC[arg0][0];
+            }
+            if (cmd < 0x1C) {
+                if (cmd >= 0x18) {
+                    e->un4C[i][4] = 0xFF;
+                }
+            }
+            if (e->un4C[i][1] == 7) {
+                if (D_800F5BE1[arg0][0] & 2) {
+                    e->un4C[i][1] = 0;
+                }
+                if (e->un4C[i][4] != 0) {
+                    if (e->un4C[i][0] != 0x19) {
+                        flags |= 0xC;
+                    }
+                }
+                cmd = e->un4C[i][0];
+                if (cmd == 5 || cmd == 0x11) {
+                    flags |= 0x10;
+                    if (e->un4C[i][4] != 0) {
+                        e->un4C[i][1] = 0;
+                    }
+                }
+            }
+            e->unk21 = i / 4 + 1;
+        }
+        e->un4C[i][2] = flags;
+    }
+    for (i = 0; i < 0x60; i++) {
+        id = e->unk108[i].unk0;
+        if (id != 0xFF) {
+            if (i >= 0x48) {
+                id += 0x48;
+            } else if (i >= 0x38) {
+                id += 0x38;
+            }
+            if (i < 0x38) {
+                if (!(D_800708D0[id][0] & 8)) {
+                    e->unk108[i].unk2 = 0;
+                }
+            }
+        }
+    }
+}
 
 void func_801B137C(s32 arg0) {
     s32 i;
@@ -95,7 +312,46 @@ void func_801B137C(s32 arg0) {
 }
 
 s32 func_80015AFC(s32, s32); // extern
-INCLUDE_ASM("asm/us/battle/nonmatchings/batini", func_801B13DC);
+
+typedef struct {
+    /* 00 */ u8 materiaID[3];
+    /* 03 */ u8 unk3[3];
+    /* 06 */ u8 count;
+    /* 07 */ u8 unk7;
+    /* 08 */ u8 unk8[0xC];
+    /* 14 */ struct {
+        u8 unk0;
+        u8 unk1[0x1B];
+    } unk14[3];
+} Unk801B13DC; // size:0x68
+
+// Resolves up to three materia slots of character arg0 against the equipment
+// mask arg1: a slot whose bit is set copies its paired value into unk3 and
+// counts towards unk6.
+void func_801B13DC(s32 arg0, s32 arg1, Unk801B13DC* arg2) {
+    s32 count;
+    s32 i;
+    s32 j;
+
+    count = 0;
+    for (i = 0; i < 3; i++) {
+        if (arg2->materiaID[i] != 0xFF) {
+            for (j = 0; j < 12; j++) {
+                if (func_80015AFC(arg0, j) == arg2->materiaID[i]) {
+                    break;
+                }
+            }
+            if (j == 12) {
+                func_800155A4(0x26);
+            } else if ((arg1 >> j) & 1) {
+                count++;
+                arg2->unk3[i] = arg2->unk14[i].unk0;
+            }
+        }
+    }
+    arg2->unk7 = 0;
+    arg2->count = count;
+}
 
 s32 func_801B14E8(u32 arg0) {
     u8 temp_v1;
@@ -121,26 +377,99 @@ s32 func_801B1530(u32* arg0) {
     return ret;
 }
 
-INCLUDE_ASM("asm/us/battle/nonmatchings/batini", func_801B1598);
+extern u8 D_80071C29[][0x10]; // accessory table, 0x10 stride
+
+// Applies party member `slot`'s equipped accessory: the status the previously
+// equipped one granted is cleared first, then the new accessory's permanent
+// status is ORed into the combatant, its turn state and the party record.
+void func_801B1598(s32 slot, s32 accessory) {
+    Unk800AF470* t;
+    Unk800F5E60* party;
+    Unk800F83E0* c;
+    u8 effect;
+
+    t = &g_CombatantTurnState.turn[slot];
+    party = &g_CombatantTurnState.party[slot];
+    c = &g_BattleState.combatant[slot];
+    c->status &= ~party->unk20;
+    t->unk34 &= ~party->unk20;
+    party->unk20 = 0;
+    t->unkD = 0xFF;
+    if (accessory != 0xFF) {
+        effect = D_80071C29[accessory][0];
+        t->unkD = effect;
+        switch (effect) {
+        case 0:
+            c->status |= STATUS_HASTE;
+            t->unk34 |= STATUS_HASTE;
+            party->unk20 |= STATUS_HASTE;
+            break;
+        case 1:
+            c->status |= STATUS_BERSERK;
+            t->unk34 |= STATUS_BERSERK;
+            party->unk20 |= STATUS_BERSERK;
+            break;
+        case 2:
+            c->status |= STATUS_D_SENTENCE;
+            t->unk34 |= STATUS_D_SENTENCE;
+            party->unk20 |= STATUS_D_SENTENCE;
+            t->unk12 = 0xFF;
+            break;
+        case 3:
+            c->status |= STATUS_REFLECT;
+            t->unk34 |= STATUS_REFLECT;
+            party->unk20 |= STATUS_REFLECT;
+            break;
+        case 6:
+            c->status |= STATUS_BARRIER | STATUS_M_BARRIER;
+            party->unk20 |= STATUS_BARRIER | STATUS_M_BARRIER;
+            break;
+        }
+    }
+}
 
 const s32 D_801B001C[] = {0x0000, 0x1000, 0x0008, 0x0800};
 const s32 D_801B002C[] = {0x0000, 0x000A, 0x0027, 0x000A};
-INCLUDE_ASM("asm/us/battle/nonmatchings/batini", func_801B1734);
+extern u8 D_800F9DA0; // pending battle-start status flags, one bit per entry
+                      // of D_801B001C / D_801B002C (bit 4 = full-heal)
+void func_800A7254(s32, s32, s32, s32);
 
-typedef struct {
-    s32 unk0;
-    s32 unk4;
-    s16 unk8;
-    s16 unkA;
-    s16 unkC;
-    s16 unkE;
-    s16 unk10;
-    s16 unk12;
-    s16 unk14;
-    s16 unk16;
-    u8 unk18[0x1C];
-} Unk801B18F8; // size:0x34
-void func_801B18F8(Unk8009D84C* arg0, Unk801B18F8* arg1, Unk800F83E0* arg2) {
+// Applies the pending battle-start effects in D_800F9DA0 to party member
+// `slot`: bit 4 restores half its max HP, bits 0-3 inflict the matching status
+// from D_801B001C unless the member's turn state already carries it. Returns
+// nonzero if any status was inflicted.
+s32 func_801B1734(s32 slot) {
+    s32 mask;
+    s32 ret;
+    s32 i;
+
+    mask = g_CombatantTurnState.turn[slot].unk34;
+    g_BattleState.combatant[slot].status &= ~STATUS_D_SENTENCE;
+    ret = 0;
+    if (g_CombatantTurnState.turn[slot].unk29 & 8) {
+        mask |= STATUS_FROG;
+    }
+    if (D_800F9DA0 & 0x10) {
+        g_BattleState.combatant[slot].curHP +=
+            g_BattleState.combatant[slot].maxHP >> 1;
+        if (g_BattleState.combatant[slot].curHP >
+            g_BattleState.combatant[slot].maxHP) {
+            g_BattleState.combatant[slot].curHP =
+                g_BattleState.combatant[slot].maxHP;
+        }
+        func_800A7254(2, slot, 0x17, 0);
+    }
+    for (i = 0; i < 4; i++) {
+        if ((D_800F9DA0 >> i) & 1) {
+            g_BattleState.combatant[slot].status |= D_801B001C[i] & ~mask;
+            func_800A7254(2, slot, 0x17, D_801B002C[i]);
+            ret = 1;
+        }
+    }
+    return ret;
+}
+
+void func_801B18F8(Unk8009D84C* arg0, Unk800F5E60* arg1, Unk800F83E0* arg2) {
     arg2->unk14 = arg0->unk6;
     arg2->unk15 = arg0->unk7;
     arg2->maxHP = arg0->unk12;
@@ -152,21 +481,182 @@ void func_801B18F8(Unk8009D84C* arg0, Unk801B18F8* arg1, Unk800F83E0* arg2) {
     if (arg2->unkD == 0) {
         arg2->unkD = 1;
     }
-    arg1->unk12 = arg2->maxHP;
-    arg1->unk10 = arg2->unk2A;
+    arg1->maxHP = arg2->maxHP;
+    arg1->maxMP = arg2->unk2A;
     if (arg0->unk23 & 8) {
-        arg1->unk16 = 999;
-        arg1->unk14 = 9999;
+        arg1->capHP = 999;
+        arg1->capMP = 9999;
     } else {
-        arg1->unk16 = 9999;
-        arg1->unk14 = 999;
+        arg1->capHP = 9999;
+        arg1->capMP = 999;
     }
 }
 
 const u8 D_801B003C[] = {0xFF, 0x32, 0x33, 0x34, 0x35, 0xFF, 0x48, 0x07};
-INCLUDE_ASM("asm/us/battle/nonmatchings/batini", func_801B19AC);
+extern u16 D_8016376E[3];
+extern s16 D_801636BE[][8]; // stride 0x10
+void func_800B1060(s32);
 
-INCLUDE_ASM("asm/us/battle/nonmatchings/batini", func_801B1CB0);
+// Lays out the two sides for the opening of the battle. D_801B003C picks the
+// intro animation for the battle type, then the type decides which rows the
+// party and the enemies occupy (row[0]/row[1]/row[2]) and which combatants
+// start "turned around" (bit 0x80 of unk4) -- back attacks, side attacks and
+// pincers each split the party differently. Finally the front/back row bit is
+// re-derived for the three party slots.
+void func_801B19AC(void) {
+    u16 row[3];
+    s32 enemyMask;
+    s32 partyMask;
+    s32 sideMask;
+    u16 mask;
+    s32 back;
+    s32 intro;
+    s32 i;
+
+    enemyMask = g_BattleState.unk12;
+    partyMask = g_BattleState.unk10;
+    sideMask = 5;
+    if (D_8016360C.setup.type == SETUP_SIDE_ATTACK_3) {
+        sideMask = ~5;
+    }
+    intro = D_801B003C[D_800F5F44.D_800F7DC8];
+    if (intro != 0xFF && g_BattleState.sceneID != 0x3D6) {
+        func_800B1060(intro);
+    }
+    mask = 0;
+    row[0] = 0;
+    row[1] = 0;
+    row[2] = 0;
+    switch (D_800F5F44.D_800F7DC8) {
+    case 0:
+        mask = enemyMask;
+        /* fallthrough */
+    case 1:
+        row[0] = partyMask;
+        row[1] = enemyMask;
+        break;
+    case 2:
+        mask = partyMask;
+        row[0] = enemyMask;
+        row[1] = mask;
+        break;
+    case 4:
+        row[1] = partyMask;
+        for (i = 0; i < 6; i++) {
+            if ((enemyMask >> (i + 4)) & 1) {
+                row[g_BattleState.combatant[i + 4].unk4 & 2] |= 1 << (i + 4);
+            }
+        }
+        mask = row[2] | (partyMask & 2);
+        if (g_BattleState.sceneID == 0x3D6) {
+            mask &= ~partyMask;
+        }
+        break;
+    default:
+        row[0] = partyMask & sideMask;
+        row[1] = enemyMask;
+        row[2] = partyMask & ~sideMask;
+        mask = row[2];
+        for (i = 0; i < 6; i++) {
+            if (((enemyMask >> (i + 4)) & 1) && D_80163624.unk34[i].unk6 >= 0) {
+                mask |= 1 << (i + 4);
+            }
+        }
+        break;
+    }
+    for (i = 0; i < 10; i++) {
+        g_BattleState.combatant[i].unk4 &= ~0x82;
+        if ((row[2] >> i) & 1) {
+            g_BattleState.combatant[i].unk4 |= 2;
+        }
+        if ((mask >> i) & 1) {
+            g_BattleState.combatant[i].unk4 |= 0x80;
+        }
+    }
+    for (i = 0; i < 3; i++) {
+        back = g_BattleState.combatant[i].unk4 >> 6;
+        back &= 1;
+        switch (D_800F5F44.D_800F7DC8) {
+        case 0:
+        case 1:
+            break;
+        case 2:
+            back = !back;
+            g_BattleState.combatant[i].unk4 ^= 0x40;
+            break;
+        default:
+            back = 0;
+            g_BattleState.combatant[i].unk4 &= ~0x40;
+            break;
+        }
+        D_801636BE[i][0] = back;
+    }
+    D_8016376E[0] = row[0];
+    D_8016376E[1] = row[1];
+    D_8016376E[2] = row[2];
+}
+
+extern u16 D_8009CBE0[];     // item inventory (320 slots; (count << 9) | id)
+extern u16 D_800722D6[][14]; // item table, stride 0x1C
+extern u8 D_800722D8[][28];
+extern u16 D_800738CA[][22]; // weapon table, stride 0x2C
+extern u8 D_800738A0[][44];
+extern u16 D_80071E64[][18]; // armor table, stride 0x24
+extern u16 D_80071C32[][8];  // accessory table, stride 0x10
+extern u8 D_80166F74;
+extern BattleItemEntry D_801671B8[];
+
+// Builds the in-battle item list from the inventory: every one of the 320
+// inventory slots becomes one BattleItemEntry, with the target and restriction
+// flags pulled from the item / weapon / armor / accessory table the id falls
+// in. D_80166F74 ends up as half the number of slots up to the last used one
+// (at least 3) -- the row count the item widget scrolls over.
+void func_801B1CB0(void) {
+    BattleItemEntry* entry;
+    s32 i;
+    s32 last;
+    s32 rows;
+    s32 id;
+    s32 count;
+    s32 targetFlags;
+    s32 flags;
+
+    last = 0;
+    for (i = 0; i < 0x140; i++) {
+        entry = &D_801671B8[i];
+        id = D_8009CBE0[i];
+        count = 0;
+        targetFlags = 0;
+        flags = 0xB;
+        if (id != 0xFFFF) {
+            count = (u32)id >> 9;
+            id &= 0x1FF;
+            if (id < 0x80) {
+                flags = D_800722D6[id][0] & 0xB;
+                targetFlags = D_800722D8[id][0];
+            } else if (id < 0x100) {
+                flags = D_800738CA[id - 0x80][0] & 0xB;
+                targetFlags = D_800738A0[id - 0x80][0];
+            } else if (id < 0x120) {
+                flags = D_80071E64[id - 0x100][0] & 0xB;
+                targetFlags = 3;
+            } else if (id < 0x140) {
+                flags = D_80071C32[id - 0x120][0] & 0xB;
+                targetFlags = 3;
+            }
+            last = i + 1;
+        }
+        entry->id = id;
+        entry->count = count;
+        entry->targetFlags = targetFlags;
+        entry->unk4 = flags;
+    }
+    rows = (last + 1) / 2;
+    if (rows < 3) {
+        rows = 3;
+    }
+    D_80166F74 = rows;
+}
 
 INCLUDE_ASM("asm/us/battle/nonmatchings/batini", func_801B1E0C);
 

--- a/src/battle/battle.h
+++ b/src/battle/battle.h
@@ -72,7 +72,7 @@ typedef struct {
     // condition/status bitmask; see BattleStatusFlags above for the bits
     // confirmed live here
     /* 0x00 */ s32 status;
-    /* 0x04 */ s32 unk4; // battle-state flags (e.g. bit 0x40 = back row, bit
+    /* 0x04 */ u32 unk4; // battle-state flags (e.g. bit 0x40 = back row, bit
                          // 0x20 = defending)
     /* 0x08 */ s8 unk8;
     /* 0x09 */ s8 unk9;
@@ -106,12 +106,15 @@ typedef struct {
 typedef struct {
     /* 0x000 */ u16 unk0;
     /* 0x002 */ u16 presentMask; // D_800F83AE: bit per combatant present
-    /* 0x004 */ u8 unk4[0x14];   // D_800F83B0..D_800F83C0
+    /* 0x004 */ u8 unk4[0xC];    // D_800F83B0..D_800F83BC
+    /* 0x010 */ u16 unk10;       // D_800F83BC
+    /* 0x012 */ u16 unk12;       // D_800F83BE
+    /* 0x014 */ u8 unk14[4];     // D_800F83C0
     /* 0x018 */ u16 unk18;       // D_800F83C4
     /* 0x01A */ u16 unk1A;       // D_800F83C6
     /* 0x01C */ u16 unk1C;       // D_800F83C8
     /* 0x01E */ u16 unk1E;       // D_800F83CA
-    /* 0x020 */ s16 sceneID;     // D_800F83CC
+    /* 0x020 */ u16 sceneID;     // D_800F83CC
     /* 0x022 */ u16 unk22;       // D_800F83CE
     /* 0x024 */ u16 setupFlags;  // D_800F83D0: BattleSetupFlags
     /* 0x026 */ u16 unk26;       // D_800F83D2
@@ -396,6 +399,47 @@ typedef struct {
 } Unk801B0C98;
 
 typedef struct {
+    s16 unk0;
+    s16 unk2;
+    u16 unk4; // ATB fill gauge, saturates/compares at 0xFFFF -- unsigned
+    s16 unk6;
+    s32 unk8;
+    u8 unkC;
+    u8 unkD; // effect id of the equipped accessory (0xFF = none)
+    u8 unkE;
+    u8 unkF;
+    u8 unk10;
+    u8 unk11;
+    u8 unk12;
+    u8 unk13;
+    u8 unk14[4];
+    s32 unk18;
+    s32 unk1C;
+    s32 unk20;
+    s32 unk24;
+    u8 unk28;
+    s8 unk29;
+    s16 unk2A;
+    s32 unk2C;
+    s32 unk30;
+    s32 unk34;
+    s32 unk38;
+    u16 unk3C;
+    u16 unk3E;
+    s32 unk40;
+} Unk800AF470; // 0x44
+
+/* one battle-usable item in the in-battle item list (built from the inventory
+   by BATINI; counts are committed back when the battle ends) */
+typedef struct {
+    /* 0x0 */ u16 id;
+    /* 0x2 */ u8 count;
+    /* 0x3 */ u8 targetFlags;
+    /* 0x4 */ u8 unk4;
+    /* 0x5 */ u8 unk5;
+} BattleItemEntry; /* size: 0x6 */
+
+typedef struct {
     /* 0x00 */ SavePartyMember* partyMember;
     /* 0x04 */ u8 limitCount; // inferred: bumped when a Limit Break executes
     /* 0x05 */ u8 unk5;
@@ -415,8 +459,7 @@ typedef struct {
     /* 0x1A */ u16 unk1A;
     /* 0x1C */ u16 unk1C;
     /* 0x1E */ u16 unk1E;
-    /* 0x20 */ u16 unk20;
-    /* 0x22 */ u16 unk22;
+    /* 0x20 */ u32 unk20; // status mask granted by the equipped accessory
     /* 0x24 */ u16 unk24;
     /* 0x26 */ u16 unk26;
     /* 0x28 */ u16 unk28;

--- a/src/battle/battle_private.h
+++ b/src/battle/battle_private.h
@@ -19,33 +19,6 @@ typedef struct {
 } Unk8009D866; // 0x440
 
 typedef struct {
-    s16 unk0;
-    s16 unk2;
-    u16 unk4; // ATB fill gauge, saturates/compares at 0xFFFF -- unsigned
-    s16 unk6;
-    s32 unk8;
-    s16 unkC;
-    u8 unkE;
-    u8 unkF;
-    s32 unk10;
-    u8 unk14[4];
-    s32 unk18;
-    s32 unk1C;
-    s32 unk20;
-    s32 unk24;
-    u8 unk28;
-    s8 unk29;
-    s16 unk2A;
-    s32 unk2C;
-    s32 unk30;
-    s32 unk34;
-    s32 unk38;
-    u16 unk3C;
-    u16 unk3E;
-    s32 unk40;
-} Unk800AF470; // 0x44
-
-typedef struct {
     s8 unk0;
     s8 unk1;
     s8 unk2;
@@ -627,16 +600,6 @@ void func_800E15D8(void);
 void func_800E5814(void);
 void func_800E6B94(void);
 void BATTLE_EnqueueLoadImage(RECT* rect, u_long* ptr);
-
-/* one battle-usable item in the in-battle item list (built from the inventory
-   at battle start; counts are committed back when the battle ends) */
-typedef struct {
-    /* 0x0 */ u16 id;
-    /* 0x2 */ u8 count;
-    /* 0x3 */ u8 targetFlags;
-    /* 0x4 */ u8 unk4;
-    /* 0x5 */ u8 unk5;
-} BattleItemEntry; /* size: 0x6 */
 
 /* battle menu widget block (one per widget id, 0x240 apart) -- partial */
 typedef struct {

--- a/src/world/world.c
+++ b/src/world/world.c
@@ -2388,7 +2388,7 @@ void func_800B832C(void) {
 
 // type?
 void func_800B8488(FieldScriptHeader* fieldScripts) {
-    D_8008326C = 0xFF;
+    D_8008326C[0] = 0xFF;
     g_CurrentEntity = 0xFF;
     g_FieldScripts = fieldScripts;
     fieldScripts->stringOffset = 8;


### PR DESCRIPTION
First PR and actually first decomp work overall. So please bear with me.

batini.c went 11 → 3 INCLUDE_ASM


Heavily AI assisted. Ran all the checks myself and imo result is sound.


**Additions and refactoring of struct definitions:**

* Added `Unk8009D954` struct to represent a single equipped-materia slot for a party member, and incorporated an array of these into the `Unk8009D84C` struct, clarifying the representation of equipped materia. [[1]](diffhunk://#diff-4dbceb2f69232a451b571009bbb93e8c561300b5c08d314cafe8a39f5c49d6d2R412-R419) [[2]](diffhunk://#diff-4dbceb2f69232a451b571009bbb93e8c561300b5c08d314cafe8a39f5c49d6d2L432-R454)
* Added `Unk800AF470` struct for detailed party member battle state, and moved its definition from `battle_private.h` to `battle.h` for better visibility and organization. [[1]](diffhunk://#diff-dd027089a2f983d920329613207c55bbd50c00db8d2bd3087811f8fa9d9e0e76R401-R441) [[2]](diffhunk://#diff-4f75a3e80c7950033690c02e033c869306e362285b1d95079f74de88f05c8942L21-L47)
* Added and relocated the `BattleItemEntry` struct definition, which represents a single battle-usable item, from `battle_private.h` to `battle.h`. [[1]](diffhunk://#diff-dd027089a2f983d920329613207c55bbd50c00db8d2bd3087811f8fa9d9e0e76R401-R441) [[2]](diffhunk://#diff-4f75a3e80c7950033690c02e033c869306e362285b1d95079f74de88f05c8942L631-L640)

**Type and array size corrections:**

* Changed the type of several struct members for accuracy, such as updating `unk4` from `s32` to `u32` and `sceneID` from `s16` to `u16` in battle-related structs. [[1]](diffhunk://#diff-dd027089a2f983d920329613207c55bbd50c00db8d2bd3087811f8fa9d9e0e76L75-R75) [[2]](diffhunk://#diff-dd027089a2f983d920329613207c55bbd50c00db8d2bd3087811f8fa9d9e0e76L109-R117)
* Adjusted array sizes and added new fields in `Unk8009D84C` to more precisely map to the underlying data, and updated `D_8008326C` from a single `u8` to an array of four elements, with corresponding code updates. [[1]](diffhunk://#diff-4dbceb2f69232a451b571009bbb93e8c561300b5c08d314cafe8a39f5c49d6d2L432-R454) [[2]](diffhunk://#diff-4dbceb2f69232a451b571009bbb93e8c561300b5c08d314cafe8a39f5c49d6d2L824-R842) [[3]](diffhunk://#diff-de24d310b45ac493334b8c07d35e0aec6a983cbd03831191fa8e56c3a392de71L2391-R2391)

**Battle struct improvements:**

* Expanded and clarified the layout of several battle-related structs, such as splitting out status masks and adding new fields to better match the actual memory layout and intended use.