### PR TITLE
battle.c: decompile the item-drop roll and action sound dispatch

### DIFF
--- a/src/battle/batini.c
+++ b/src/battle/batini.c
@@ -724,7 +724,7 @@ static void func_801B23E0(s32 sceneID, void (*cb)(void)) {
         D_8016360C.setup.escapeCounter = 1;
         // enemy strength and magic is 25% higher at battle square
         for (i = 0; i < 3; i++) {
-            D_800F5F44.enemy[i].unk90[5] *= 2;
+            D_800F5F44.enemy[i].unk94[4] *= 2;
             D_800F5F44.enemy[i].strength = func_801B2770(D_800F5F44.enemy[i].strength);
             D_800F5F44.enemy[i].magic = func_801B2770(D_800F5F44.enemy[i].magic);
         }

--- a/src/battle/battle.c
+++ b/src/battle/battle.c
@@ -1884,7 +1884,47 @@ void func_800ACA24(void) {
     g_CurrentAction->unk214 = 0;
 }
 
-INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800ACA4C);
+void func_800ACA4C(s32 arg0) {
+    u16 args[2];
+    s32 sound;
+    s32 id;
+    u8 effect;
+
+    sound = 3;
+    switch (g_CurrentAction->unk28) {
+    case 2:
+        sound = 0x38;
+        break;
+    case 3:
+        sound = 0x36;
+        break;
+    case 13:
+        sound = 0x37;
+        break;
+    case 20:
+        sound = 0x35;
+        break;
+    }
+    id = g_CurrentAction->actorId;
+    if (id < 3) {
+        func_800A2CC4(sound);
+        if (arg0 != -1) {
+            func_800B1060(arg0);
+            func_800A2CC4(0x3B);
+        }
+        if (sound == 3) {
+            func_800A2CC4(4);
+        }
+    } else if (arg0 != -1) {
+        args[0] = id;
+        args[1] = 0xFFFF;
+        effect = g_CombatantTurnState[g_CurrentAction->actorId].unkF;
+        if (effect != 0xFF) {
+            args[1] = effect;
+        }
+        func_800B0FFC(g_CurrentAction->actorId, arg0, 1, (s16*)args);
+    }
+}
 
 INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800ACB98);
 
@@ -2568,7 +2608,32 @@ s32 func_800B0EB4(s32 arg0) {
     return count & 1;
 }
 
-INCLUDE_ASM("asm/us/battle/nonmatchings/battle", func_800B0F04);
+u16 func_800B0F04(SceneEnemy* e, s32 kind, s32 always, s32 rate) {
+    SceneEnemy* p;
+    u16 item;
+    s32 chance;
+    s32 i;
+    s32 v;
+
+    p = e;
+    item = 0xFFFF;
+    for (i = 0; i < 4; i++) {
+        v = p->itemRate[i];
+        if ((v & ~0x3F) == kind) {
+            chance = v & 0x3F;
+            if (always != 0) {
+                chance = 0x100;
+            } else {
+                chance = (chance * rate) / 256;
+            }
+            if (chance >= (SysGetRandomByteFromTable() & 0x3F)) {
+                item = p->itemId[i];
+                break;
+            }
+        }
+    }
+    return item;
+}
 
 void func_800B0FFC(s32 arg0, s32 arg1, s32 arg2, s16* arg3) {
     func_800A31A0(arg0, 2, arg2, BATTLE_ExpandScriptToBuffer(SysGetPtrToUncompKernBattleTxtWithId(arg1), arg3) + 0x100);

--- a/src/battle/battle.h
+++ b/src/battle/battle.h
@@ -205,9 +205,9 @@ typedef struct {
     /* 0x82 */ u8 backAttackMul;
     /* 0x83 */ u8 unk83;
     /* 0x84 */ s32 exp;
-    /* 0x88 */ s32 gil;
-    /* 0x8C */ s32 statusImmunities;
-    /* 0x90 */ u32 unk90[10];
+    /* 0x88 */ u8 itemRate[4]; /* drop/steal rate, high 2 bits select the kind */
+    /* 0x8C */ u16 itemId[4];  /* item awarded for the matching slot */
+    /* 0x94 */ u32 unk94[9];
 } SceneEnemy; // size:0xB8
 
 // https://github.com/petfriendamy/ff7-scarlet/blob/main/src/Shared/DataParser.cs


### PR DESCRIPTION
Two more battle.c functions, rebased onto current main now that #129 landed.

The item-drop roll needed `SceneEnemy`'s trailing padding split into `itemRate[4]`/`itemId[4]` -- the drop chance and item id per slot were sitting in what used to be one opaque `unk90` blob.